### PR TITLE
Rotate page to better represent comics and other horisontal pdfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,19 @@ $(LUALIB):
 
 thirdparty: $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIBS)
 
+INSTALL_DIR=kindlepdfviewer
+
 install:
 	# install to kindle using USB networking
-	scp kpdfview *.lua root@192.168.2.2:/mnt/us/test/
+	scp kpdfview *.lua root@192.168.2.2:/mnt/us/$(INSTALL_DIR)/
 	scp launchpad/* root@192.168.2.2:/mnt/us/launchpad/
 
+VERSION?=$(shell git rev-parse --short HEAD)
+customupdate: kpdfview
+	# ensure that build binary is for ARM
+	file kpdfview | grep ARM || exit 1
+	mkdir $(INSTALL_DIR)
+	cp -p README.TXT COPYING kpdfview *.lua $(INSTALL_DIR)
+	zip -r kindlepdfviewer-$(VERSION).zip $(INSTALL_DIR) launchpad/
+	rm -Rf $(INSTALL_DIR)
+	@echo "copy kindlepdfviewer-$(VERSION).zip to /mnt/us/customupdates and install with shift+shift+I"

--- a/README.TXT
+++ b/README.TXT
@@ -61,3 +61,9 @@ The reader.lua script needs a device argument in order to cope with some
 slight differences between actual readers and the emulation. Run it like
 this:
 	./reader.lua -d emu /PATH/TO/PDF.pdf
+
+By default emulation will provide DXG resolution of 824*1200. It can be
+specified at compile time, this is example for Kindle 3:
+
+	EMULATE_READER_W=600 EMULATE_READER_H=800 EMULATE_READER=1 make kpdfview
+

--- a/keys.lua
+++ b/keys.lua
@@ -121,6 +121,10 @@ function set_emu_keycodes()
 	KEY_A = 38
 	KEY_S = 39
 	KEY_D = 40
+
+	KEY_J = 44
+	KEY_K = 45
+
 	KEY_SHIFT = 50 -- left shift
 	KEY_ALT = 64   -- left alt
 	KEY_VPLUS = 95  -- F11

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -2,13 +2,5 @@
 echo unlock > /proc/keypad
 echo unlock > /proc/fiveway
 cd /mnt/us/test/
-cat /dev/fb0 > /tmp/screen.fb0 &
-if [ "x$1" == "x" ] ; then
-	pdf=`lsof | grep /mnt/us/documents | cut -c81- | sort -u`
-else
-	pdf="$1"
-fi
-./reader.lua "$pdf"
-cat /tmp/screen.fb0 > /dev/fb0
-rm /tmp/screen.fb0
+./reader.lua /mnt/us/documents
 echo 1 > /proc/eink_fb/update_display

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo unlock > /proc/keypad
 echo unlock > /proc/fiveway
-cd /mnt/us/test/
+cd /mnt/us/kindlepdfviewer/
 ./reader.lua /mnt/us/documents
 echo 1 > /proc/eink_fb/update_display

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -288,7 +288,7 @@ function PDFReader:inputloop()
 			elseif ev.code == KEY_PGFWD then
 				if self.shiftmode then
 					self:setglobalzoom(self.globalzoom*1.2)
-				elseif altmode then
+				elseif self.altmode then
 					self:setglobalzoom(self.globalzoom*1.1)
 				else
 					self:goto(self.pageno + 1)
@@ -296,7 +296,7 @@ function PDFReader:inputloop()
 			elseif ev.code == KEY_PGBCK then
 				if self.shiftmode then
 					self:setglobalzoom(self.globalzoom*0.8)
-				elseif altmode then
+				elseif self.altmode then
 					self:setglobalzoom(self.globalzoom*0.9)
 				else
 					self:goto(self.pageno - 1)

--- a/reader.lua
+++ b/reader.lua
@@ -40,6 +40,7 @@ if optarg["h"] or ARGV[optind] == nil then
 	print("                          (floating point notation, e.g. \"1.5\")")
 	print("-d, --device=DEVICE       set device specific configuration,")
 	print("                          currently one of \"kdxg\" (default), \"k3\"")
+	print("                          \"emu\" (DXG emulation)")
 	print("-h, --help                show this usage help")
 	print("")
 	print("If you give the name of a directory instead of a path, a file")

--- a/reader.lua
+++ b/reader.lua
@@ -63,6 +63,15 @@ elseif optarg["d"] == "emu" then
 else
 	input.open("/dev/input/event0")
 	input.open("/dev/input/event1")
+
+	-- check if we are running on Kindle 3 (additional volume input)
+	local f=lfs.attributes("/dev/input/event2")
+	print(f)
+	if f then
+		print("Auto-detected Kindle 3")
+		set_k3_keycodes()
+	end
+
 end
 
 if optarg["G"] ~= nil then


### PR DESCRIPTION
I was playing around with displaying comics, and page rotation came to mind. I implemented artificially small increment of 10 degrees to demonstrate point of rotation (which seems to be upper left).

It's eye candy in this phase, because all clipping are wrong after rotation. I was hoping that moving of rotation before or after clipping will change that, but it didn't ;-) Now, I'm stuck deciding whether to implement additional fixes after rotation or just special cases for 0, 90, 180 and 270 degrees.

Am I missing something in mupdf? I scanned through apps/pdfapp.c which comes with mupdf, and it seems they are mainlining clippings separate from mupdf's dc notion of viewport, but you might have better ideas, I'm sure :-)
