### PR TITLE
implement new two-column zoom mode (F)

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -163,14 +163,7 @@ function FileChooser:choose(ypos, height)
 			elseif ev.code == KEY_S then -- invoke search input
 				keywords = InputBox:input(height-100, 100, "Search:")
 				if keywords then -- display search result according to keywords
-					--[[
-						----------------------------------------------------------------
-						|| uncomment following line and set the correct path if you want
-						|| to test search feature in EMU mode
-						----------------------------------------------------------------
-					--]]
-					--FileSearcher:init("/home/dave/documents/kindle/backup/documents")
-					FileSearcher:init()
+					FileSearcher:init( self.path )
 					file = FileSearcher:choose(ypos, height, keywords)
 					if file then
 						return file

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -40,6 +40,8 @@ PDFReader = {
 	shift_x = 100,
 	shift_y = 50,
 	pan_by_page = false, -- using shift_[xy] or width/height
+	pan_x = 0, -- top-left offset of page when pan activated
+	pan_y = 0,
 
 	-- keep track of input state:
 	shiftmode = false, -- shift pressed
@@ -366,8 +368,8 @@ function PDFReader:inputloop()
 					self:setglobalzoom(self.globalzoom+0.1)
 				else
 					if self.pan_by_page then
-						self.offset_x = 0
-						self.offset_y = 0
+						self.offset_x = self.pan_x
+						self.offset_y = self.pan_y
 					end
 					self:goto(self.pageno + 1)
 				end
@@ -378,8 +380,8 @@ function PDFReader:inputloop()
 					self:setglobalzoom(self.globalzoom-0.1)
 				else
 					if self.pan_by_page then
-						self.offset_x = 0
-						self.offset_y = 0
+						self.offset_x = self.pan_x
+						self.offset_y = self.pan_y
 					end
 					self:goto(self.pageno - 1)
 				end
@@ -462,7 +464,7 @@ function PDFReader:inputloop()
 						self.offset_x = 0
 					end
 					if self.pan_by_page then
-						self.offset_y = 0
+						self.offset_y = self.pan_y
 					end
 				elseif ev.code == KEY_FW_RIGHT then
 					self.offset_x = self.offset_x - x
@@ -470,7 +472,7 @@ function PDFReader:inputloop()
 						self.offset_x = self.min_offset_x
 					end
 					if self.pan_by_page then
-						self.offset_y = 0
+						self.offset_y = self.pan_y
 					end
 				elseif ev.code == KEY_FW_UP then
 					self.offset_y = self.offset_y + y
@@ -484,10 +486,19 @@ function PDFReader:inputloop()
 					end
 				elseif ev.code == KEY_FW_PRESS then
 					if self.shiftmode then
-						self.offset_x = 0
-						self.offset_y = 0
+						if self.pan_by_page then
+							self.offset_x = self.pan_x
+							self.offset_y = self.pan_y
+						else
+							self.offset_x = 0
+							self.offset_y = 0
+						end
 					else
 						self.pan_by_page = not self.pan_by_page
+						if self.pan_by_page then
+							self.pan_x = self.offset_x
+							self.pan_y = self.offset_y
+						end
 					end
 				end
 				if old_offset_x ~= self.offset_x

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -480,12 +480,12 @@ function PDFReader:inputloop()
 						self.offset_x = 0
 						if self.pan_by_page and self.pageno > 1 then
 							self.offset_x = self.pan_x
-							self.offset_y = self.pan_y
+							self.offset_y = self.min_offset_y -- bottom
 							self:goto(self.pageno - 1)
 						end
 					end
 					if self.pan_by_page then
-						self.offset_y = self.pan_y
+						self.offset_y = self.min_offset_y
 					end
 				elseif ev.code == KEY_FW_RIGHT then
 					self.offset_x = self.offset_x - x

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -478,6 +478,11 @@ function PDFReader:inputloop()
 					self.offset_x = self.offset_x + x
 					if self.offset_x > 0 then
 						self.offset_x = 0
+						if self.pan_by_page and self.pageno > 1 then
+							self.offset_x = self.pan_x
+							self.offset_y = self.pan_y
+							self:goto(self.pageno - 1)
+						end
 					end
 					if self.pan_by_page then
 						self.offset_y = self.pan_y
@@ -486,6 +491,11 @@ function PDFReader:inputloop()
 					self.offset_x = self.offset_x - x
 					if self.offset_x < self.min_offset_x then
 						self.offset_x = self.min_offset_x
+						if self.pan_by_page and self.pageno < self.doc:getPages() then
+							self.offset_x = self.pan_x
+							self.offset_y = self.pan_y
+							self:goto(self.pageno + 1)
+						end
 					end
 					if self.pan_by_page then
 						self.offset_y = self.pan_y

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -198,7 +198,7 @@ function PDFReader:setzoom(page)
 		self.globalzoom = width / (x1 - x0 + self.pan_margin)
 		self.offset_x = -1 * x0 * self.globalzoom * 2 + self.pan_margin
 		self.globalzoom = height / (y1 - y0)
-		self.offset_y = -1 * y0 * self.globalzoom * 2
+		self.offset_y = -1 * y0 * self.globalzoom * 2 + self.pan_margin
 		self.globalzoom = width / (x1 - x0 + self.pan_margin) * 2
 		print("column mode offset:"..self.offset_x.."*"..self.offset_y.." zoom:"..self.globalzoom);
 		self.globalzoommode = self.ZOOM_BY_VALUE -- enable pan mode
@@ -463,8 +463,8 @@ function PDFReader:inputloop()
 					x = self.shift_x / 5
 					y = self.shift_y / 5
 				elseif self.pan_by_page then
-					x = width  - 5; -- small overlap when moving by page
-					y = height - 5;
+					x = width;
+					y = height - self.pan_margin; -- overlap for lines which didn't fit
 				else
 					x = self.shift_x
 					y = self.shift_y

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -370,6 +370,7 @@ function PDFReader:inputloop()
 	while 1 do
 		local ev = input.waitForEvent()
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
+			ev.code = adjustFWKey(ev.code)
 			local secs, usecs = util.gettime()
 			if ev.code == KEY_SHIFT then
 				self.shiftmode = true


### PR DESCRIPTION
This set of changes implement two-column zoom mode in which you can use just fiveway to move up or down in current column and left-right to change column (and pages if needed).

Current implementation will always position on top of column for right move (which make sense when reading paper) or to bottom on left move (which makes sense to have a quick look at end of last column or when scanning article backwards)

I toyed with idea of implementing this move using page buttons in Kindle, but somehow, I prefer to leave they as they are if you really want to change pages.
