### PR TITLE
four bug fixes & one refactoring

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -146,9 +146,13 @@ function FileChooser:choose(ypos, height)
 		end
 		local ev = input.waitForEvent()
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
-			--print("key code:"..ev.code)
+			print("key code:"..ev.code)
 			ev.code = adjustFWKey(ev.code)
-			if ev.code == KEY_FW_UP then
+			if ev.code == KEY_SHIFT then
+				Keys.shiftmode = true
+			elseif ev.code == KEY_ALT then
+				Keys.altmode = true
+			elseif ev.code == KEY_FW_UP then
 				prevItem()
 			elseif ev.code == KEY_FW_DOWN then
 				nextItem()
@@ -214,6 +218,12 @@ function FileChooser:choose(ypos, height)
 			elseif ev.code == KEY_BACK then
 				return nil
 			end
+		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
+		and ev.code == KEY_SHIFT then
+			Keys.shiftmode = false
+		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
+		and ev.code == KEY_ALT then
+			Keys.altmode = false
 		end
 	end
 end

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -144,15 +144,12 @@ function FileChooser:choose(ypos, height)
 			fb:refresh(0, 0, ypos, fb.bb:getWidth(), height)
 			pagedirty = false
 		end
+
 		local ev = input.waitForEvent()
+		print("key code:"..ev.code)
+		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
-			print("key code:"..ev.code)
-			ev.code = adjustFWKey(ev.code)
-			if ev.code == KEY_SHIFT then
-				Keys.shiftmode = true
-			elseif ev.code == KEY_ALT then
-				Keys.altmode = true
-			elseif ev.code == KEY_FW_UP then
+			if ev.code == KEY_FW_UP then
 				prevItem()
 			elseif ev.code == KEY_FW_DOWN then
 				nextItem()
@@ -211,12 +208,6 @@ function FileChooser:choose(ypos, height)
 			elseif ev.code == KEY_BACK then
 				return nil
 			end
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_SHIFT then
-			Keys.shiftmode = false
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_ALT then
-			Keys.altmode = false
 		end
 	end
 end

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -214,13 +214,9 @@ function FileSearcher:choose(ypos, height, keywords)
 		end
 
 		local ev = input.waitForEvent()
+		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
-			ev.code = adjustFWKey(ev.code)
-			if ev.code == KEY_SHIFT then
-				Keys.shiftmode = true
-			elseif ev.code == KEY_ALT then
-				Keys.altmode = true
-			elseif ev.code == KEY_FW_UP then
+			if ev.code == KEY_FW_UP then
 				prevItem()
 			elseif ev.code == KEY_FW_DOWN then
 				nextItem()
@@ -276,12 +272,6 @@ function FileSearcher:choose(ypos, height, keywords)
 			elseif ev.code == KEY_BACK then
 				return nil
 			end
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_SHIFT then
-			Keys.shiftmode = false
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_ALT then
-			Keys.altmode = false
 		end
 	end
 end

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -216,7 +216,11 @@ function FileSearcher:choose(ypos, height, keywords)
 		local ev = input.waitForEvent()
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			ev.code = adjustFWKey(ev.code)
-			if ev.code == KEY_FW_UP then
+			if ev.code == KEY_SHIFT then
+				Keys.shiftmode = true
+			elseif ev.code == KEY_ALT then
+				Keys.altmode = true
+			elseif ev.code == KEY_FW_UP then
 				prevItem()
 			elseif ev.code == KEY_FW_DOWN then
 				nextItem()
@@ -272,6 +276,12 @@ function FileSearcher:choose(ypos, height, keywords)
 			elseif ev.code == KEY_BACK then
 				return nil
 			end
+		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
+		and ev.code == KEY_SHIFT then
+			Keys.shiftmode = false
+		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
+		and ev.code == KEY_ALT then
+			Keys.altmode = false
 		end
 	end
 end

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -43,7 +43,7 @@ function FileSearcher:readdir()
 		for __, d in pairs(self.dirs) do
 			-- handle files in d
 			for f in lfs.dir(d) do
-				if lfs.attributes(self.path.."/"..f, "mode") == "directory"
+				if lfs.attributes(d.."/"..f, "mode") == "directory"
 				and f ~= "." and f~= ".." and not string.match(f, "^%.[^.]") then
 					table.insert(new_dirs, d.."/"..f)
 				elseif string.match(f, ".+%.[pP][dD][fF]$") then

--- a/inputbox.lua
+++ b/inputbox.lua
@@ -98,14 +98,10 @@ function InputBox:input(ypos, height, title, d_text)
 		end
 
 		local ev = input.waitForEvent()
+		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
-			ev.code = adjustFWKey(ev.code)
 			--local secs, usecs = util.gettime()
-			if ev.code == KEY_SHIFT then
-				Keys.shiftmode = true
-			elseif ev.code == KEY_ALT then
-				Keys.altmode = true
-			elseif ev.code == KEY_FW_UP then
+			if ev.code == KEY_FW_UP then
 			elseif ev.code == KEY_FW_DOWN then
 			elseif ev.code == KEY_A then
 				self:addChar("a")
@@ -198,12 +194,6 @@ function InputBox:input(ypos, height, title, d_text)
 			--local nsecs, nusecs = util.gettime()
 			--local dur = (nsecs - secs) * 1000000 + nusecs - usecs
 			--print("E: T="..ev.type.." V="..ev.value.." C="..ev.code.." DUR="..dur)
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_SHIFT then
-			Keys.shiftmode = false
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_ALT then
-			Keys.altmode = false
 		end
 	end
 end

--- a/inputbox.lua
+++ b/inputbox.lua
@@ -102,9 +102,9 @@ function InputBox:input(ypos, height, title, d_text)
 			ev.code = adjustFWKey(ev.code)
 			--local secs, usecs = util.gettime()
 			if ev.code == KEY_SHIFT then
-				self.shiftmode = true
+				Keys.shiftmode = true
 			elseif ev.code == KEY_ALT then
-				self.altmode = true
+				Keys.altmode = true
 			elseif ev.code == KEY_FW_UP then
 			elseif ev.code == KEY_FW_DOWN then
 			elseif ev.code == KEY_A then
@@ -200,10 +200,10 @@ function InputBox:input(ypos, height, title, d_text)
 			--print("E: T="..ev.type.." V="..ev.value.." C="..ev.code.." DUR="..dur)
 		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
 		and ev.code == KEY_SHIFT then
-			self.shiftmode = false
+			Keys.shiftmode = false
 		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
 		and ev.code == KEY_ALT then
-			self.altmode = false
+			Keys.altmode = false
 		end
 	end
 end

--- a/keys.lua
+++ b/keys.lua
@@ -201,7 +201,23 @@ function getRotationMode()
 	return mode
 end
 
-function adjustFWKey(code)
+function adjustKeyEvents(ev)
+	if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
+		if ev.code == KEY_SHIFT then
+			Keys.shiftmode = true
+		elseif ev.code == KEY_ALT then
+			Keys.altmode = true
+		end
+	elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE then
+		if ev.code == KEY_SHIFT then
+			Keys.shiftmode = false
+		elseif ev.code == KEY_ALT then
+			Keys.altmode = false
+		end
+	end
+
+	-- adjust five way key according to rotation mode
+	local code = ev.code
 	if getRotationMode() == 0 then
 		return code
 	elseif getRotationMode() == 1 then

--- a/keys.lua
+++ b/keys.lua
@@ -24,6 +24,11 @@
     and was licensed under the GPLv2
 ]]--
 
+Keys = {
+	altmode = false,
+	shiftmode = false,
+}
+
 KEY_1 = 2
 KEY_2 = 3
 KEY_3 = 4
@@ -120,6 +125,17 @@ function set_emu_keycodes()
 
 	KEY_ENTER = 36
 
+	KEY_1 = 10
+	KEY_2 = 11
+	KEY_3 = 12
+	KEY_4 = 13
+	KEY_5 = 14
+	KEY_6 = 15
+	KEY_7 = 16
+	KEY_8 = 17
+	KEY_9 = 18
+	KEY_0 = 19
+
 	KEY_Q = 24
 	KEY_W = 25
 	KEY_E = 26
@@ -163,17 +179,17 @@ function getRotationMode()
 	1 for landscape with bottom on the right side of screen, etc.
 
 	         2
-	    -----------
-	   |  -------  |
+	   +-----------+
+	   | +-------+ |
 	   | |       | |
 	   | |       | |
 	   | |       | |  
 	 3 | |       | | 1
 	   | |       | |
 	   | |       | |
-	   |  -------  |
+	   | +-------+ |
 	   |           |
-	    -----------
+	   +-----------+
 	         0
 	--]]
 	if KEY_FW_DOWN == 116 then -- in EMU mode always return 0

--- a/pdf.c
+++ b/pdf.c
@@ -104,6 +104,17 @@ static int walkTableOfContent(lua_State *L, fz_outline* ol, int *count, int dept
 		lua_pushnumber(L, depth); 
 		lua_settable(L, -3);
 		lua_pushstring(L, "title");
+
+		/* workaround for misplaced carriage ret in toc entry */
+		int i = 0;
+		while (ol->title[i]) {
+			if (ol->title[i] == 0x0d) {
+				ol->title[i] = ' ';
+			}
+			/*printf("%x|", ol->title[i]);*/
+			i++;
+		}
+
 		lua_pushstring(L, ol->title);
 		lua_settable(L, -3);
 

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -356,27 +356,27 @@ function PDFReader:inputloop()
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			local secs, usecs = util.gettime()
 			if ev.code == KEY_SHIFT then
-				self.shiftmode = true
+				Keys.shiftmode = true
 			elseif ev.code == KEY_ALT then
-				self.altmode = true
+				Keys.altmode = true
 			elseif ev.code == KEY_PGFWD or ev.code == KEY_LPGFWD then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:setglobalzoom(self.globalzoom*1.2)
-				elseif self.altmode then
+				elseif Keys.altmode then
 					self:setglobalzoom(self.globalzoom*1.1)
 				else
 					self:goto(self.pageno + 1)
 				end
 			elseif ev.code == KEY_PGBCK or ev.code == KEY_LPGBCK then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:setglobalzoom(self.globalzoom*0.8)
-				elseif self.altmode then
+				elseif Keys.altmode then
 					self:setglobalzoom(self.globalzoom*0.9)
 				else
 					self:goto(self.pageno - 1)
 				end
 			elseif ev.code == KEY_BACK then
-				if self.altmode then
+				if Keys.altmode then
 					-- altmode, exit pdfreader
 					self:clearcache()
 					if self.doc ~= nil then
@@ -399,19 +399,19 @@ function PDFReader:inputloop()
 			elseif ev.code == KEY_VMINUS then
 				self:modify_gamma( 0.8 )
 			elseif ev.code == KEY_A then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:setglobalzoommode(self.ZOOM_FIT_TO_CONTENT)
 				else
 					self:setglobalzoommode(self.ZOOM_FIT_TO_PAGE)
 				end
 			elseif ev.code == KEY_S then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:setglobalzoommode(self.ZOOM_FIT_TO_CONTENT_WIDTH)
 				else
 					self:setglobalzoommode(self.ZOOM_FIT_TO_PAGE_WIDTH)
 				end
 			elseif ev.code == KEY_D then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:setglobalzoommode(self.ZOOM_FIT_TO_CONTENT_HEIGHT)
 				else
 					self:setglobalzoommode(self.ZOOM_FIT_TO_PAGE_HEIGHT)
@@ -430,10 +430,10 @@ function PDFReader:inputloop()
 				local x
 				local y
 
-				if self.shiftmode then -- shift always moves in small steps
+				if Keys.shiftmode then -- shift always moves in small steps
 					x = self.shift_x / 2
 					y = self.shift_y / 2
-				elseif self.altmode then
+				elseif Keys.altmode then
 					x = self.shift_x / 5
 					y = self.shift_y / 5
 				elseif self.pan_by_page then
@@ -469,7 +469,7 @@ function PDFReader:inputloop()
 						self.offset_y = self.min_offset_y
 					end
 				elseif ev.code == KEY_FW_PRESS then
-					if self.shiftmode then
+					if Keys.shiftmode then
 						self.offset_x = 0
 						self.offset_y = 0
 					else
@@ -487,9 +487,9 @@ function PDFReader:inputloop()
 			print("E: T="..ev.type.." V="..ev.value.." C="..ev.code.." DUR="..dur)
 		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE and ev.code == KEY_SHIFT then
 			print "shift haha"
-			self.shiftmode = false
+			Keys.shiftmode = false
 		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE and ev.code == KEY_ALT then
-			self.altmode = false
+			Keys.altmode = false
 		end
 	end
 end

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -45,10 +45,6 @@ PDFReader = {
 	pan_y = 0,
 	pan_margin = 20,
 
-	-- keep track of input state:
-	shiftmode = false, -- shift pressed
-	altmode = false,   -- alt pressed
-
 	-- the pdf document:
 	doc = nil,
 	-- the document's setting store:
@@ -369,17 +365,13 @@ end
 function PDFReader:inputloop()
 	while 1 do
 		local ev = input.waitForEvent()
+		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
-			ev.code = adjustFWKey(ev.code)
 			local secs, usecs = util.gettime()
-			if ev.code == KEY_SHIFT then
-				Keys.shiftmode = true
-			elseif ev.code == KEY_ALT then
-				Keys.altmode = true
-			elseif ev.code == KEY_PGFWD or ev.code == KEY_LPGFWD then
-				if self.shiftmode then
+			if ev.code == KEY_PGFWD or ev.code == KEY_LPGFWD then
+				if Keys.shiftmode then
 					self:setglobalzoom(self.globalzoom+0.2)
-				elseif self.altmode then
+				elseif Keys.altmode then
 					self:setglobalzoom(self.globalzoom+0.1)
 				else
 					if self.pan_by_page then
@@ -389,9 +381,9 @@ function PDFReader:inputloop()
 					self:goto(self.pageno + 1)
 				end
 			elseif ev.code == KEY_PGBCK or ev.code == KEY_LPGBCK then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:setglobalzoom(self.globalzoom-0.2)
-				elseif self.altmode then
+				elseif Keys.altmode then
 					self:setglobalzoom(self.globalzoom-0.1)
 				else
 					if self.pan_by_page then
@@ -512,7 +504,7 @@ function PDFReader:inputloop()
 						self.offset_y = self.min_offset_y
 					end
 				elseif ev.code == KEY_FW_PRESS then
-					if self.shiftmode then
+					if Keys.shiftmode then
 						if self.pan_by_page then
 							self.offset_x = self.pan_x
 							self.offset_y = self.pan_y
@@ -537,11 +529,6 @@ function PDFReader:inputloop()
 			local nsecs, nusecs = util.gettime()
 			local dur = (nsecs - secs) * 1000000 + nusecs - usecs
 			print("E: T="..ev.type.." V="..ev.value.." C="..ev.code.." DUR="..dur)
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE and ev.code == KEY_SHIFT then
-			print "shift haha"
-			Keys.shiftmode = false
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE and ev.code == KEY_ALT then
-			Keys.altmode = false
 		end
 	end
 end

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -442,7 +442,7 @@ function PDFReader:inputloop()
 			elseif ev.code == KEY_T then
 				self:showTOC()
 			elseif ev.code == KEY_B then
-				if self.shiftmode then
+				if Keys.shiftmode then
 					self:add_jump(self.pageno)
 				else
 					self:showJumpStack()

--- a/reader.lua
+++ b/reader.lua
@@ -117,4 +117,7 @@ reader_settings:savesetting("cfont", FontChooser.cfont)
 reader_settings:close()
 
 input.closeAll()
-os.execute('test -e /proc/keypad && echo "send '..KEY_HOME..'" > /proc/keypad ')
+--os.execute('test -e /proc/keypad && echo "send '..KEY_HOME..'" > /proc/keypad ')
+if optarg["d"] ~= "emu" then
+	os.execute('echo "send '..KEY_MENU..'" > /proc/keypad;echo "send '..KEY_MENU..'" > /proc/keypad')
+end

--- a/selectmenu.lua
+++ b/selectmenu.lua
@@ -167,13 +167,9 @@ function SelectMenu:choose(ypos, height)
 		end
 
 		local ev = input.waitForEvent()
+		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
-			ev.code = adjustFWKey(ev.code)
-			if ev.code == KEY_SHIFT then
-				Keys.shiftmode = true
-			elseif ev.code == KEY_ALT then
-				Keys.altmode = true
-			elseif ev.code == KEY_FW_UP then
+			if ev.code == KEY_FW_UP then
 				prevItem()
 			elseif ev.code == KEY_FW_DOWN then
 				nextItem()
@@ -205,12 +201,6 @@ function SelectMenu:choose(ypos, height)
 			elseif ev.code == KEY_BACK then
 				return nil
 			end
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_SHIFT then
-			Keys.shiftmode = false
-		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
-		and ev.code == KEY_ALT then
-			Keys.altmode = false
 		end
 	end
 end

--- a/selectmenu.lua
+++ b/selectmenu.lua
@@ -169,7 +169,11 @@ function SelectMenu:choose(ypos, height)
 		local ev = input.waitForEvent()
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			ev.code = adjustFWKey(ev.code)
-			if ev.code == KEY_FW_UP then
+			if ev.code == KEY_SHIFT then
+				Keys.shiftmode = true
+			elseif ev.code == KEY_ALT then
+				Keys.altmode = true
+			elseif ev.code == KEY_FW_UP then
 				prevItem()
 			elseif ev.code == KEY_FW_DOWN then
 				nextItem()
@@ -201,6 +205,12 @@ function SelectMenu:choose(ypos, height)
 			elseif ev.code == KEY_BACK then
 				return nil
 			end
+		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
+		and ev.code == KEY_SHIFT then
+			Keys.shiftmode = false
+		elseif ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_RELEASE
+		and ev.code == KEY_ALT then
+			Keys.altmode = false
 		end
 	end
 end


### PR DESCRIPTION
# fix
- change misplaced carriage ret characters (0x0d) in TOC entry
  to white space (0x20) to avoid displaying empty boxes.
- move shiftmode and altmode to global

now shiftmode and altmode is recoreded in Keys module.  So all the UIs
are sharing these two mode instead of remembering their own. These fix
the bug in UI switching.

For instance, you use combo 'Alt'+'b' to fire up some menu in pdfreader,
the altmode is set, but the alt key was released after the menu show
up. Then the key release event will only be captured by the menu. So
after you exit from the menu, the altmode is still set in pdfreader,
which is not what we want.
- refresh screen more elegantly after reader exit
- fix bug in recursive searching in filesearcher
# refactoring
- handle shift and alt key events in adjustKeyEvents(), to minimize code duplication.
