### PR TITLE
#35 manual crop for odd and even pages

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -406,8 +406,10 @@ function UniReader:goto(no)
 
 	if no < self.doc:getPages() then
 		if self.globalzoommode ~= self.ZOOM_BY_VALUE then
-			-- pre-cache next page
-			self:draworcache(no+1,self.globalzoommode,self.offset_x,self.offset_y,width,height,self.globalgamma,self.globalrotate)
+			if #self.bbox == 0 then
+				-- pre-cache next page, but if we will modify bbox don't!
+				self:draworcache(no+1,self.globalzoommode,self.offset_x,self.offset_y,width,height,self.globalgamma,self.globalrotate)
+			end
 		else
 			self:draworcache(no,self.globalzoom,self.offset_x,self.offset_y,width,height,self.globalgamma,self.globalrotate)
 		end

--- a/unireader.lua
+++ b/unireader.lua
@@ -115,6 +115,10 @@ function UniReader:loadSettings(filename)
 		local jumpstack = self.settings:readsetting("jumpstack")
 		self.jump_stack = jumpstack or {}
 
+		local bbox = self.settings:readsetting("bbox")
+		print("# bbox loaded "..dump(bbox))
+		self.bbox = bbox
+
 		return true
 	end
 	return false
@@ -124,10 +128,6 @@ function UniReader:initGlobalSettings(settings)
 	local pan_overlap_vertical = settings:readsetting("pan_overlap_vertical")
 	if pan_overlap_vertical then
 		self.pan_overlap_vertical = pan_overlap_vertical
-	end
-	local bbox = settings:readsetting("bbox")
-	if bbox then
-		self.bbox = bbox
 	end
 end
 
@@ -607,7 +607,6 @@ end
 -- wait for input and handle it
 function UniReader:inputloop()
 	local keep_running = true
-	self.bbox = {}
 	while 1 do
 		local ev = input.waitForEvent()
 		ev.code = adjustKeyEvents(ev)
@@ -695,7 +694,7 @@ function UniReader:inputloop()
 					keep_running = false
 				end
 				break
-			elseif ev.code == KEY_Z then
+			elseif ev.code == KEY_Z and not Keys.shiftmode then
 				local bbox = {}
 				bbox["x0"] = - self.offset_x / self.globalzoom
 				bbox["y0"] = - self.offset_y / self.globalzoom
@@ -705,6 +704,9 @@ function UniReader:inputloop()
 				self.bbox[self:odd_even(self.pageno)] = bbox
 				print("# bbox " .. self.pageno .. dump(self.bbox)) 
 				self.globalzoommode = self.ZOOM_FIT_TO_CONTENT -- use bbox
+			elseif ev.code == KEY_Z and Keys.shiftmode then
+				self.bbox[self.pageno] = nil;
+				print("# bbox remove "..self.pageno .. dump(self.bbox));
 			end
 
 			-- switch to ZOOM_BY_VALUE to enable panning on fiveway move

--- a/unireader.lua
+++ b/unireader.lua
@@ -119,6 +119,9 @@ function UniReader:loadSettings(filename)
 		print("# bbox loaded "..dump(bbox))
 		self.bbox = bbox
 
+		self.globalzoom = self.settings:readsetting("globalzoom") or 1.0
+		self.globalzoommode = self.settings:readsetting("globalzoommode") or -1
+
 		return true
 	end
 	return false
@@ -700,6 +703,8 @@ function UniReader:inputloop()
 				bbox["y0"] = - self.offset_y / self.globalzoom
 				bbox["x1"] = bbox["x0"] + width / self.globalzoom
 				bbox["y1"] = bbox["y0"] + height / self.globalzoom
+				bbox.pan_x = self.pan_x
+				bbox.pan_y = self.pan_y
 				self.bbox[self.pageno] = bbox
 				self.bbox[self:odd_even(self.pageno)] = bbox
 				self.bbox.enabled = true
@@ -832,6 +837,8 @@ function UniReader:inputloop()
 		self.settings:savesetting("jumpstack", self.jump_stack)
 		--self.settings:savesetting("pan_overlap_vertical", self.pan_overlap_vertical)
 		self.settings:savesetting("bbox", self.bbox)
+		self.settings:savesetting("globalzoom", self.globalzoom)
+		self.settings:savesetting("globalzoommode", self.globalzoommode)
 		self.settings:close()
 	end
 

--- a/unireader.lua
+++ b/unireader.lua
@@ -198,13 +198,22 @@ function UniReader:setzoom(page)
 	if self.bbox then
 		print("# ORIGINAL page::getUsedBBox "..x0.."*"..y0.." "..x1.."*"..y1);
 		local bbox = self.bbox[self.pageno] -- exact
-		if bbox == nil then
-			bbox = self.bbox[self:odd_even(self.pageno)] -- odd/even
+
+		local odd_even = self:odd_even(self.pageno)
+		if bbox ~= nil then
+			print("## bbox from "..self.pageno)
+		else
+			bbox = self.bbox[odd_even] -- odd/even
 		end
-		if bbox == nil then -- last used up to this page
+		if bbox ~= nil then -- last used up to this page
+			print("## bbox from "..odd_even)
+		else
 			for i = 0,self.pageno do
 				bbox = self.bbox[ self.pageno - i ]
-				if bbox ~= nil then break end
+				if bbox ~= nil then
+					print("## bbox from "..self.pageno - i)
+					break
+				end
 			end
 		end
 		if bbox ~= nil then

--- a/unireader.lua
+++ b/unireader.lua
@@ -125,6 +125,10 @@ function UniReader:initGlobalSettings(settings)
 	if pan_overlap_vertical then
 		self.pan_overlap_vertical = pan_overlap_vertical
 	end
+	local bbox = settings:readsetting("bbox")
+	if bbox then
+		self.bbox = bbox
+	end
 end
 
 -- guarantee that we have enough memory in cache
@@ -820,6 +824,8 @@ function UniReader:inputloop()
 		self.settings:savesetting("last_page", self.pageno)
 		self.settings:savesetting("gamma", self.globalgamma)
 		self.settings:savesetting("jumpstack", self.jump_stack)
+		--self.settings:savesetting("pan_overlap_vertical", self.pan_overlap_vertical)
+		self.settings:savesetting("bbox", self.bbox)
 		self.settings:close()
 	end
 

--- a/unireader.lua
+++ b/unireader.lua
@@ -209,7 +209,7 @@ function UniReader:setzoom(page)
 	if y0 < 0 then y0 = 0 end
 	if y1 > pheight then y1 = pheight end
 
-	if self.bbox then
+	if self.bbox.enabled then
 		print("# ORIGINAL page::getUsedBBox "..x0.."*"..y0.." "..x1.."*"..y1);
 		local bbox = self.bbox[self.pageno] -- exact
 
@@ -433,7 +433,7 @@ function UniReader:goto(no)
 
 	if no < self.doc:getPages() then
 		if self.globalzoommode ~= self.ZOOM_BY_VALUE then
-			if #self.bbox == 0 then
+			if #self.bbox == 0 or not self.bbox.enabled then
 				-- pre-cache next page, but if we will modify bbox don't!
 				self:draworcache(no+1,self.globalzoommode,self.offset_x,self.offset_y,width,height,self.globalgamma,self.globalrotate)
 			end
@@ -702,11 +702,15 @@ function UniReader:inputloop()
 				bbox["y1"] = bbox["y0"] + height / self.globalzoom
 				self.bbox[self.pageno] = bbox
 				self.bbox[self:odd_even(self.pageno)] = bbox
+				self.bbox.enabled = true
 				print("# bbox " .. self.pageno .. dump(self.bbox)) 
 				self.globalzoommode = self.ZOOM_FIT_TO_CONTENT -- use bbox
 			elseif ev.code == KEY_Z and Keys.shiftmode then
 				self.bbox[self.pageno] = nil;
 				print("# bbox remove "..self.pageno .. dump(self.bbox));
+			elseif ev.code == KEY_Z and Keys.altmode then
+				self.bbox.enabled = not self.bbox.enabled;
+				print("# bbox override "..self.bbox.enabled);
 			end
 
 			-- switch to ZOOM_BY_VALUE to enable panning on fiveway move


### PR DESCRIPTION
This allows separate bounding boxes for odd and even pages which makes possible to read two-column layout when papers are irregular odd/even page layout.
