### PR TITLE
3 fixes

### DIFF
--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -265,7 +265,7 @@ function FileSearcher:choose(ypos, height, keywords)
 				openFile(file_full_path)
 
 				pagedirty = true
-			elseif ev.code == KEY_BACK then
+			elseif ev.code == KEY_BACK or ev.code == KEY_HOME then
 				return nil
 			end
 		end

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-export LC_ALL=en_US.UTF-8 
+export LC_ALL="en_US.UTF-8"
 
 echo unlock > /proc/keypad
 echo unlock > /proc/fiveway

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+export LC_ALL=en_US.UTF-8 
+
 echo unlock > /proc/keypad
 echo unlock > /proc/fiveway
 cd /mnt/us/kindlepdfviewer/

--- a/unireader.lua
+++ b/unireader.lua
@@ -697,7 +697,7 @@ function UniReader:inputloop()
 					keep_running = false
 				end
 				break
-			elseif ev.code == KEY_Z and not Keys.shiftmode then
+			elseif ev.code == KEY_Z and not (Keys.shiftmode or Keys.altmode) then
 				local bbox = {}
 				bbox["x0"] = - self.offset_x / self.globalzoom
 				bbox["y0"] = - self.offset_y / self.globalzoom
@@ -715,7 +715,7 @@ function UniReader:inputloop()
 				print("# bbox remove "..self.pageno .. dump(self.bbox));
 			elseif ev.code == KEY_Z and Keys.altmode then
 				self.bbox.enabled = not self.bbox.enabled;
-				print("# bbox override "..self.bbox.enabled);
+				print("# bbox override: ", self.bbox.enabled);
 			end
 
 			-- switch to ZOOM_BY_VALUE to enable panning on fiveway move


### PR DESCRIPTION
- The `alt`+`z` binding was over taken by `elseif ev.code == KEY_Z and not (Keys.shiftmode or Keys.altmode) then` check.
- exit filesearcher with `HOME`
- export `LC_ALL` to `en_US.UTF-8` in kpdf.sh so we can handle file name with non-ascii characters
- compile error in mupdf
