### PR TITLE
Try to fix some bugs in new cache system

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -219,7 +219,7 @@ function UniReader:draworcache(no, preCache)
 	-- so render now.
 	-- start off with the requested area
 	local tile = { x = offset_x_in_page, y = offset_y_in_page, 
-					w = width, h = heigth }
+					w = width, h = height }
 	-- can we cache the full page?
 	local max_cache = self.cache_max_memsize
 	if preCache then

--- a/unireader.lua
+++ b/unireader.lua
@@ -272,8 +272,6 @@ function UniReader:draworcache(no, preCache)
 	page:draw(dc, self.cache[pagehash].bb, 0, 0)
 	page:close()
 
-	print("offset_x_in_page", offset_x_in_page)
-	print("offset_y_in_page", offset_y_in_page)
 	-- return hash and offset within blitbuffer
 	return pagehash,
 		offset_x_in_page - tile.x,


### PR DESCRIPTION
I am not sure my fixes are right or not, but at least it works for me. ;)

In draworcache method, I added `offset_x_in_page` and `offset_y_in_page` variables to represents offset within page the page to draw. So we don't need to use `self.offset_x` and `self.offset_y` in following calculations. `self.offset_x` and `self.offset_y` might be positive or negative, which is easy to introduce bugs. 
- The first bug is not handling positive self.offset values, which leads to this output: http://imgur.com/7Ku01
- I am the one to blame for the second bug: ZOOM_FIT_TO_CONTENT_WIDTH_PAN mode is not taken into consider. This leads to this output: http://imgur.com/1hrBu. I added ZOOM_FIT_TO_CONTENT_WIDTH_PAN mode to simulate the page turning experience in native reader days before. ;P

Besides what I mentioned above, the new cache system works great, I can observe that when panning in ZOOM mode, no page:draw() method is called :)
