### PR TITLE
Screen rotation handling for entering/leaving screen saver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ THIRDPARTYLIBS := $(MUPDFLIBDIR)/libfreetype.a \
 
 LUALIB := $(LUADIR)/src/liblua.a
 
+all:kpdfview slider_watcher
+
 kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o util.o ft.o lfs.o $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) $(DJVULIBS) djvu.o
 	$(CC) -lm -ldl -lpthread $(EMU_LDFLAGS) -lstdc++ \
 		kpdfview.o \
@@ -83,6 +85,9 @@ kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o util.o ft
 
 einkfb.o input.o: %.o: %.c
 	$(CC) -c $(KPDFREADER_CFLAGS) $(EMU_CFLAGS) $< -o $@
+
+slider_watcher: slider_watcher.c
+	$(CC) $(CFLAGS) $< -o $@
 
 ft.o: %.o: %.c
 	$(CC) -c $(KPDFREADER_CFLAGS) -I$(FREETYPEDIR)/include $< -o $@
@@ -107,7 +112,7 @@ fetchthirdparty:
 	tar xvzf lua-5.1.4.tar.gz && ln -s lua-5.1.4 lua
 
 clean:
-	-rm -f *.o kpdfview
+	-rm -f *.o kpdfview slider_watcher
 
 cleanthirdparty:
 	make -C $(LUADIR) clean

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ customupdate: kpdfview
 	# ensure that build binary is for ARM
 	file kpdfview | grep ARM || exit 1
 	mkdir $(INSTALL_DIR)
-	cp -p README.TXT COPYING kpdfview *.lua $(INSTALL_DIR)
+	cp -p README.TXT COPYING kpdfview slider_watcher *.lua $(INSTALL_DIR)
 	zip -r kindlepdfviewer-$(VERSION).zip $(INSTALL_DIR) launchpad/
 	rm -Rf $(INSTALL_DIR)
 	@echo "copy kindlepdfviewer-$(VERSION).zip to /mnt/us/customupdates and install with shift+shift+I"

--- a/input.c
+++ b/input.c
@@ -22,8 +22,8 @@
 #include <linux/input.h>
 #include "input.h"
 
-#define NUM_FDS 3
-int inputfds[3] = { -1, -1, -1 };
+#define NUM_FDS 4
+int inputfds[4] = { -1, -1, -1, -1 };
 
 static int openInputDevice(lua_State *L) {
 #ifndef EMULATE_READER

--- a/keys.lua
+++ b/keys.lua
@@ -87,6 +87,9 @@ KEY_FW_UP = 122
 KEY_FW_DOWN = 123
 KEY_FW_PRESS = 92
 
+KEY_INTO_SCREEN_SAVER = 10000
+KEY_OUTOF_SCREEN_SAVER = 10001
+
 -- constants from <linux/input.h>
 EV_KEY = 1
 

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
+SLIDER_EVENT_PIPE="/tmp/event_slider"
 export LC_ALL="en_US.UTF-8"
 
 echo unlock > /proc/keypad
 echo unlock > /proc/fiveway
 cd /mnt/us/kindlepdfviewer/
+
+# create the named pipe for power slider event
+if [ ! -p $SLIDER_EVENT_PIPE ]; then
+	mkfifo $SLIDER_EVENT_PIPE
+fi
+killall slider_watcher
+./slider_watcher $SLIDER_EVENT_PIPE &
+
 ./reader.lua $1 2> /mnt/us/kindlepdfviewer/crash.log
 echo 1 > /proc/eink_fb/update_display

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -14,4 +14,5 @@ killall slider_watcher
 ./slider_watcher $SLIDER_EVENT_PIPE &
 
 ./reader.lua $1 2> /mnt/us/kindlepdfviewer/crash.log
+killall -cont cvm
 echo 1 > /proc/eink_fb/update_display

--- a/reader.lua
+++ b/reader.lua
@@ -173,6 +173,6 @@ fb:setOrientation(Screen.native_rotation_mode)
 
 input.closeAll()
 if optarg["d"] ~= "emu" then
-	os.execute("killall -cont cvm")
+	--os.execute("killall -cont cvm")
 	os.execute('echo "send '..KEY_MENU..'" > /proc/keypad;echo "send '..KEY_MENU..'" > /proc/keypad')
 end

--- a/reader.lua
+++ b/reader.lua
@@ -92,6 +92,7 @@ if optarg["d"] == "k3" then
 	input.open("/dev/input/event0")
 	input.open("/dev/input/event1")
 	input.open("/dev/input/event2")
+	input.open("/tmp/event_slider")
 	setK3Keycodes()
 elseif optarg["d"] == "emu" then
 	input.open("")
@@ -100,6 +101,7 @@ elseif optarg["d"] == "emu" then
 else
 	input.open("/dev/input/event0")
 	input.open("/dev/input/event1")
+	input.open("/tmp/event_slider")
 
 	-- check if we are running on Kindle 3 (additional volume input)
 	local f=lfs.attributes("/dev/input/event2")
@@ -119,7 +121,7 @@ fb = einkfb.open("/dev/fb0")
 width, height = fb:getSize()
 -- read current rotation mode
 Screen:updateRotationMode()
-origin_rotation_mode = Screen.cur_rotation_mode
+Screen.native_rotation_mode = Screen.cur_rotation_mode
 
 -- set up reader's setting: font
 reader_settings = DocSettings:open(".reader")
@@ -167,10 +169,10 @@ reader_settings:close()
 
 -- @TODO dirty workaround, find a way to force native system poll
 -- screen orientation and upside down mode 09.03 2012
-fb:setOrientation(origin_rotation_mode)
+fb:setOrientation(Screen.native_rotation_mode)
 
 input.closeAll()
---os.execute('test -e /proc/keypad && echo "send '..KEY_HOME..'" > /proc/keypad ')
 if optarg["d"] ~= "emu" then
+	os.execute("killall -cont cvm")
 	os.execute('echo "send '..KEY_MENU..'" > /proc/keypad;echo "send '..KEY_MENU..'" > /proc/keypad')
 end

--- a/screen.lua
+++ b/screen.lua
@@ -41,6 +41,9 @@ Codes for rotation modes:
 
 Screen = {
 	cur_rotation_mode = 0,
+	-- these two variabls are used to help switching from framework to reader
+	native_rotation_mode = nil,
+	kpv_rotation_mode = nil,
 }
 
 -- @orien: 1 for clockwise rotate, -1 for anti-clockwise
@@ -70,5 +73,4 @@ function Screen:updateRotationMode()
 		self.cur_rotation_mode = orie_fd:read() + (updown_fd:read() * 2)
 	end
 end
-
 

--- a/slider_watcher.c
+++ b/slider_watcher.c
@@ -1,0 +1,87 @@
+/*
+    KindlePDFViewer: power slider key event watcher
+    Copyright (C) 2012 Qingping Hou <dave2008713@gamil.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+
+#define OUTPUT_SIZE 21
+#define EVENT_PIPE "/tmp/event_slider"
+#define CODE_IN_SAVER 10000
+#define CODE_OUT_SAVER 10001
+
+int
+main ( int argc, char *argv[] )
+{
+	int fd, ret;
+	FILE *fp;
+	char std_out[OUTPUT_SIZE] = "";
+	struct input_event ev;
+	__u16 key_code = 10000;
+
+	/* create the npipe if not exists */
+	/*if(access(argv[1], F_OK)){*/
+		/*printf("npipe %s not found, try to create it...\n", argv[1]);*/
+		/*if(mkfifo(argv[1], 0777)) {*/
+			/*printf("Create npipe %s failed!\n", argv[1]);*/
+		/*}*/
+	/*}*/
+
+	/* open npipe for writing */
+	fd = open(argv[1], O_RDWR | O_NONBLOCK);
+	if(fd < 0) {
+		printf("Open %s falied: %s\n", argv[1], strerror(errno));
+		exit(EXIT_FAILURE);
+	}
+
+	/* initialize event struct */
+	ev.type = EV_KEY;
+	ev.code = key_code;
+	ev.value = 1;
+
+	while(1) {
+		/* listen power slider events */
+		memset(std_out, 0, OUTPUT_SIZE);
+		fp = popen("lipc-wait-event  -s 0 com.lab126.powerd goingToScreenSaver,outOfScreenSaver", "r");
+		ret = fread(std_out, OUTPUT_SIZE, 1, fp);
+		pclose(fp);
+
+		/* fill event struct */
+		gettimeofday(&ev.time, NULL);
+		if(std_out[0] == 'g') {
+			ev.code = CODE_IN_SAVER;
+		} else if(std_out[0] == 'o') {
+			ev.code = CODE_OUT_SAVER;
+		} else {
+			printf("Unrecognized event.\n");
+			exit(EXIT_FAILURE);
+		}
+
+		/* generate event */
+		ret = write(fd, &ev, sizeof(struct input_event));
+	}
+
+	close(fd);
+	return EXIT_SUCCESS;
+}

--- a/unireader.lua
+++ b/unireader.lua
@@ -1219,7 +1219,6 @@ function UniReader:addAllCommands()
 			Screen.kpv_rotation_mode = Screen.cur_rotation_mode
 			fb:setOrientation(Screen.native_rotation_mode)
 			os.execute("killall -cont cvm")
-			print("resumed")
 		end)
 	self.commands:add(KEY_OUTOF_SCREEN_SAVER,nil,"slider",
 		"toggle screen saver",

--- a/unireader.lua
+++ b/unireader.lua
@@ -1211,5 +1211,21 @@ function UniReader:addAllCommands()
 			end
 		end)
 	-- end panning
+	self.commands:add(KEY_INTO_SCREEN_SAVER,nil,"slider",
+		"toggle screen saver",
+		function(unireader)
+			Screen.kpv_rotation_mode = Screen.cur_rotation_mode
+			fb:setOrientation(Screen.native_rotation_mode)
+			os.execute("killall -cont cvm")
+			print("resumed")
+		end)
+	self.commands:add(KEY_OUTOF_SCREEN_SAVER,nil,"slider",
+		"toggle screen saver",
+		function(unireader)
+			os.execute("sleep 1")
+			os.execute("killall -stop cvm")
+			fb:setOrientation(Screen.kpv_rotation_mode)
+			unireader:goto(unireader.pageno)
+		end)
 	print("## defined commands "..dump(self.commands.map))
 end

--- a/unireader.lua
+++ b/unireader.lua
@@ -347,6 +347,8 @@ function UniReader:setzoom(page, preCache)
 		x1 = pwidth
 		y1 = pheight
 	end
+	if x1 == 0 then x1 = pwidth end
+	if y1 == 0 then y1 = pheight end
 	-- clamp to page BBox
 	if x0 < 0 then x0 = 0 end
 	if x1 > pwidth then x1 = pwidth end


### PR DESCRIPTION
Not sure whether this is the best way, but at least it works :P

I gave up the idea of using ioctl on `/proc/pmic` in `input.c` because I cannot come up with a good solution to watch the event with `select` system call. So I decide to fake an event file like those in `/dev/input`.  

My first try was using the `uinput` module. But the `uinput` module in kindle seems a little wired, I can create a new file under `/dev/input`, but write to it generates no fake event. Then I switched to the named pipe.

The big change in this commit is I stopped the framework on kpv start, so if kpv crashed, people need to restart it and exit normally to resume the framework.

This pull request only fixes screen saver in readers, not filechooser, selectmenu or filesearcher. To fix this, we need to rewrite those module with the new command module. Since I have already rewritten selectmenu with command in my epub branch and the epub branch is expected to be finished in two or three days, I think it is better to merge the epub branch to master first before we rewrite those modules. Otherwise we might end up with lots of conflicts :P

PS:
I guess the `slider_watcher.c` can be better improved by calling ioctl on `/proc/pmic`, but I don't have so much free time playing on it :)

PS2:
This pull request also includes a small fix for a bug reported by eLiNK.
