### PR TITLE
fix time out crash in screen saver

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -292,7 +292,7 @@ function DJVUReader:startHighLightMode()
 
 	-- first use cursor to place start pos for highlight
 	while running do
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			if ev.code == KEY_FW_LEFT then
@@ -538,7 +538,7 @@ function DJVUReader:startHighLightMode()
 	-- go into highlight mode
 	running = true
 	while running do
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			if ev.code == KEY_FW_LEFT then

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -164,7 +164,7 @@ function FileChooser:choose(ypos, height)
 			pagedirty = false
 		end
 
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		--print("key code:"..ev.code)
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
@@ -196,7 +196,7 @@ function FileChooser:choose(ypos, height)
 					settings menu in the future.
 					--]]
 					return nil, function()
-						FileSearcher:init( self.path )
+						FileSearcher:init(self.path)
 						FileSearcher:choose(keywords)
 					end
 				end

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -291,7 +291,7 @@ function FileSearcher:choose(keywords)
 			self.pagedirty = false
 		end
 
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			keydef = Keydef:new(ev.code, getKeyModifier())

--- a/helppage.lua
+++ b/helppage.lua
@@ -74,7 +74,7 @@ function HelpPage:show(ypos, height,commands)
 			pagedirty = false
 		end
 
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		--print("key code:"..ev.code)
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then

--- a/input.c
+++ b/input.c
@@ -83,7 +83,7 @@ static int waitForInput(lua_State *L) {
 
 	num = select(nfds, &fds, NULL, NULL, &timeout);
 	if(num < 0) {
-		return luaL_error(L, "Waiting for input failed: %d\n", errno);
+		return 0;
 	}
 
 	for(i=0; i<NUM_FDS; i++) {
@@ -107,6 +107,7 @@ static int waitForInput(lua_State *L) {
 			}
 		}
 	}
+
 	return 0;
 #else
 	SDL_Event event;

--- a/inputbox.lua
+++ b/inputbox.lua
@@ -135,7 +135,7 @@ function InputBox:input(ypos, height, title, d_text)
 	fb:refresh(1, 20, ypos, w, h)
 
 	while true do
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			--local secs, usecs = util.gettime()

--- a/keys.lua
+++ b/keys.lua
@@ -254,3 +254,11 @@ function adjustKeyEvents(ev)
 	print("# Unrecognizable rotation mode "..Screen.cur_rotation_mode.."!")
 	return nil
 end
+
+function waitForEvent()
+	local ev = nil
+	while not ev do
+		ev = input.waitForEvent()
+	end
+	return ev
+end

--- a/rendertext_example.lua
+++ b/rendertext_example.lua
@@ -23,5 +23,5 @@ renderUtf8Text(fb.bb, 100, 200, face, "h", "AV T.T: gxyt!", false)
 fb:refresh()
 
 while true do
-	local ev = input.waitForEvent()
+	local ev = waitForEvent()
 end

--- a/selectmenu.lua
+++ b/selectmenu.lua
@@ -319,7 +319,7 @@ function SelectMenu:choose(ypos, height)
 			self.pagedirty = false
 		end
 
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			keydef = Keydef:new(ev.code, getKeyModifier())

--- a/unireader.lua
+++ b/unireader.lua
@@ -883,7 +883,7 @@ function UniReader:showMenu()
 
 	fb:refresh(1)
 	while 1 do
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			if ev.code == KEY_BACK or ev.code == KEY_MENU then
@@ -908,7 +908,7 @@ end
 function UniReader:inputLoop()
 	local keep_running = true
 	while 1 do
-		local ev = input.waitForEvent()
+		local ev = waitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
 			local secs, usecs = util.gettime()


### PR DESCRIPTION
I modified `input.c` to return `nil`  on select timeout added a input.waitForEvent() wrapper in `key.lua` which handles nil return and keep waiting for the events.

I am wondering what is the best timeout value for select call? Current default timeout seems like about 4 minutes.
