### PR TITLE
correctly dim part of page when hitting margins

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1248,6 +1248,9 @@ function UniReader:addAllCommands()
 				elseif keydef.keycode == KEY_FW_UP then
 					unireader.offset_y = unireader.offset_y + y
 					if unireader.offset_y > 0 then
+						if unireader.pan_by_page then
+							unireader.show_overlap = unireader.offset_y + unireader.pan_overlap_vertical
+						end
 						unireader.offset_y = 0
 					elseif unireader.pan_by_page then
 						unireader.show_overlap = unireader.pan_overlap_vertical -- bottom
@@ -1255,6 +1258,9 @@ function UniReader:addAllCommands()
 				elseif keydef.keycode == KEY_FW_DOWN then
 					unireader.offset_y = unireader.offset_y - y
 					if unireader.offset_y < unireader.min_offset_y then
+						if unireader.pan_by_page then
+							unireader.show_overlap = unireader.offset_y + y - unireader.min_offset_y - G_height
+						end
 						unireader.offset_y = unireader.min_offset_y
 					elseif unireader.pan_by_page then
 						unireader.show_overlap = -unireader.pan_overlap_vertical -- top


### PR DESCRIPTION
This improves dimming when we hit top or bottom margin, which is easy testable with our test/2col.pdf but this somehow slipped my mind :-)

It has interesting effect when used in two-column mode: if you need to move very small step down or up to show rest of the page, most of screen will turn grey. While this might seem contra-intuitive at first, it honors original indentation of this feature: show parts which where visible in previous screen in gray.
