### PR TITLE
API changes in highlighting code

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -54,14 +54,22 @@ function DJVUReader:_isEntireWordInScreenHeightRange(w)
 end
 
 -- y axel in djvulibre starts from bottom
+function DJVUReader:_isEntireLineInScreenHeightRange(l)
+	return	(l ~= nil) and
+			(self.cur_full_height - (l.y1 * self.globalzoom) >=
+				-self.offset_y) and
+			(self.cur_full_height - (l.y0 * self.globalzoom) <= 
+				-self.offset_y + G_height)
+end
+
+-- y axel in djvulibre starts from bottom
 function DJVUReader:_isWordInScreenRange(w)
 	return	(w ~= nil) and
-			(self.cur_full_height - (w.y0 * self.globalzoom) >=
-				-self.offset_y) and
-			(self.cur_full_height - (w.y1 * self.globalzoom) <= 
-				-self.offset_y + G_height) and
-			(w.x1 * self.globalzoom >= -self.offset_x) and
-			(w.x0 * self.globalzoom <= -self.offset_x + G_width)
+			(self.cur_full_height - (w.y0 * self.globalzoom) >= -self.offset_y
+			or self.cur_full_height - (w.y1 * self.globalzoom) <= -self.offset_y + G_height)
+			and 
+			(w.x1 * self.globalzoom >= -self.offset_x
+			or w.x0 * self.globalzoom <= -self.offset_x + G_width)
 end
 
 

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -24,24 +24,44 @@ function DJVUReader:adjustDjvuReaderCommand()
 end
 
 
------------[ highlight support ]----------
+----------------------------------------------------
+-- highlight support 
+----------------------------------------------------
+function DJVUReader:getText(pageno)
+	return self.doc:getPageText(pageno)
+end
 
 ----------------------------------------------------
--- Given coordinates of four conners and return
--- coordinate of upper left conner with with and height
---
 -- In djvulibre library, some coordinates starts from
--- down left conner, i.e. y is upside down. This method
--- only transform these coordinates.
+-- lower left conner, i.e. y is upside down in kpv's
+-- coordinate. So y0 should be taken with special care.
 ----------------------------------------------------
-function DJVUReader:rectCoordTransform(x0, y0, x1, y1)
+function DJVUReader:zoomedRectCoordTransform(x0, y0, x1, y1)
 	return 
-		self.offset_x + x0 * self.globalzoom,
-		self.offset_y + self.cur_full_height - (y1 * self.globalzoom),
+		x0 * self.globalzoom,
+		self.cur_full_height - (y1 * self.globalzoom),
 		(x1 - x0) * self.globalzoom,
 		(y1 - y0) * self.globalzoom
 end
 
-function DJVUReader:getText(pageno)
-	return self.doc:getPageText(pageno)
+-- y axel in djvulibre starts from bottom
+function DJVUReader:_isEntireWordInScreenHeightRange(w)
+	return	(w ~= nil) and
+			(self.cur_full_height - (w.y1 * self.globalzoom) >=
+				-self.offset_y) and
+			(self.cur_full_height - (w.y0 * self.globalzoom) <= 
+				-self.offset_y + G_height)
 end
+
+-- y axel in djvulibre starts from bottom
+function DJVUReader:_isWordInScreenRange(w)
+	return	(w ~= nil) and
+			(self.cur_full_height - (w.y0 * self.globalzoom) >=
+				-self.offset_y) and
+			(self.cur_full_height - (w.y1 * self.globalzoom) <= 
+				-self.offset_y + G_height) and
+			(w.x1 * self.globalzoom >= -self.offset_x) and
+			(w.x0 * self.globalzoom <= -self.offset_x + G_width)
+end
+
+

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -31,16 +31,9 @@ function PDFReader:open(filename)
 	return true
 end
 
------------[ highlight support ]----------
-
-function PDFReader:rectCoordTransform(x0, y0, x1, y1)
-	return
-		x0 * self.globalzoom,
-		y1 * self.globalzoom - self.offset_y,
-		x1 - x0,
-		y1 - y0
-end
-
+----------------------------------------------------
+-- highlight support 
+----------------------------------------------------
 function PDFReader:getText(pageno)
 	local ok, page = pcall(self.doc.openPage, self.doc, pageno)
 	if not ok then

--- a/unireader.lua
+++ b/unireader.lua
@@ -117,7 +117,7 @@ end
 ----------------------------------------------------
 
 ----------------------------------------------------
--- Given coordinates of four conners in oringinal page
+-- Given coordinates of four corners in original page
 -- size and return coordinate of upper left conner in 
 -- zoomed page size with width and height.
 ----------------------------------------------------
@@ -130,15 +130,15 @@ function UniReader:zoomedRectCoordTransform(x0, y0, x1, y1)
 end
 
 ----------------------------------------------------
--- Given coordinates of four conners in oringinal page
--- size and return Rectangular area in screen. You
+-- Given coordinates of four corners in original page
+-- size and return rectangular area in screen. You
 -- might want to call this when you want to draw stuff
 -- on screen.
 --
--- NOTE: this method doese not check whether given area
+-- NOTE: this method does not check whether given area
 -- is can be shown in current screen. Make sure to check
 -- with _isEntireWordInScreenRange() before you want to
--- draw on screen.
+-- draw on the returned area.
 ----------------------------------------------------
 function UniReader:getRectInScreen(x0, y0, x1, y1)
 	x, y, w, h = self:zoomedRectCoordTransform(x0, y0, x1, y1)
@@ -154,7 +154,6 @@ function UniReader:_isEntireWordInScreenRange(w)
 			self:_isEntireWordInScreenWidthRange(w)
 end
 
--- y axel in djvulibre starts from bottom
 function UniReader:_isEntireWordInScreenHeightRange(w)
 	return	(w ~= nil) and
 			(w.y1 * self.globalzoom) >= -self.offset_y
@@ -231,7 +230,7 @@ function UniReader:_wordIterFromRange(t, l0, w0, l1, w1)
 			end
 			return i, j
 		end
-	end -- EOF closure
+	end -- closure
 end
 
 function UniReader:_toggleWordHighLight(t, l, w)


### PR DESCRIPTION
I found the naming of `UniReader:rectCoordTransform()` does not make sense at all and leads to confusion, so I split it into two methods: `UniReader:zoomedRectCoordTransform()` and `UniReader:getRectInScreen()`. I also added some more comments to explain these two methods, hope it helps.

Current highlight feature works very well for my PDFs and no breaks in DjVus, great work @hwhw :)
