### PR TITLE
show_overlap calculation bug in two column mode

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1925,6 +1925,7 @@ function UniReader:addAllCommands()
 							unireader.offset_y = unireader.min_offset_y -- bottom
 							unireader:goto(unireader.pageno - 1)
 						else
+							unireader.show_overlap = 0
 							unireader.offset_y = unireader.min_offset_y
 						end
 					elseif unireader.offset_x > 0 then
@@ -1939,6 +1940,7 @@ function UniReader:addAllCommands()
 							unireader.offset_y = unireader.pan_y
 							unireader:goto(unireader.pageno + 1)
 						else
+							unireader.show_overlap = 0
 							unireader.offset_y = unireader.pan_y
 						end
 					elseif unireader.offset_x < unireader.min_offset_x then


### PR DESCRIPTION
I suspect I found a bug in two column mode, though not sure.

When reading our two column mode test file, pan to the bottom of left column, then press one more five way key down, then press five way key right to go to next column, and you will get a -800 show_overlap, so the whole screen is dimmed.
