### PR TITLE
make highlight working in all zoom modes #103

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -37,9 +37,16 @@ end
 -- coordinate. So y0 should be taken with special care.
 ----------------------------------------------------
 function DJVUReader:zoomedRectCoordTransform(x0, y0, x1, y1)
+	local x = self.dest_x
+	local y = self.dest_y
+	if self.offset_x < 0 or self.offset_y < 0 then
+		x = x + self.offset_x
+		y = y + self.offset_y
+	end
+	print("# zoomedRectCoordTransform x="..x.." y="..y.." dest="..self.dest_x..","..self.dest_y.." offset="..self.offset_x..","..self.offset_y);
 	return 
-		x0 * self.globalzoom,
-		self.cur_full_height - (y1 * self.globalzoom),
+		x0 * self.globalzoom + x,
+		self.cur_full_height - (y1 * self.globalzoom) + y,
 		(x1 - x0) * self.globalzoom,
 		(y1 - y0) * self.globalzoom
 end

--- a/unireader.lua
+++ b/unireader.lua
@@ -1186,11 +1186,13 @@ function UniReader:setzoom(page, preCache)
 		or self.globalzoommode == self.ZOOM_FIT_TO_CONTENT_HALF_WIDTH_MARGIN then
 		local margin = self.pan_margin
 		if self.globalzoommode == self.ZOOM_FIT_TO_CONTENT_HALF_WIDTH then margin = 0 end
-		self.globalzoom = width / (x1 - x0 + margin)
+		local pg_margin = 0 -- margin scaled to page size
+		if margin > 0 then pg_margin = margin * 2 / self.globalzoom end
+		self.globalzoom = width / (x1 - x0 + pg_margin)
 		self.offset_x = -1 * x0 * self.globalzoom * 2 + margin
-		self.globalzoom = height / (y1 - y0)
+		self.globalzoom = height / (y1 - y0 + pg_margin)
 		self.offset_y = -1 * y0 * self.globalzoom * 2 + margin
-		self.globalzoom = width / (x1 - x0 + margin) * 2
+		self.globalzoom = width / (x1 - x0 + pg_margin) * 2
 		print("column mode offset:"..self.offset_x.."*"..self.offset_y.." zoom:"..self.globalzoom);
 		self.globalzoommode = self.ZOOM_BY_VALUE -- enable pan mode
 		self.pan_x = self.offset_x


### PR DESCRIPTION
This change introduce object's dest_x and dest_y coordinates which are needed in zoomedRectCoordTransform to make highlight scale and move according to current pan position.
