### PR TITLE
rewrite jump stack and add bookmark feature

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -168,14 +168,15 @@ function Commands:new(obj)
 			Screen:saveCurrentBB()
 			Screen.kpv_rotation_mode = Screen.cur_rotation_mode
 			fb:setOrientation(Screen.native_rotation_mode)
-			--os.execute("killall -cont cvm")
+			util.sleep(1)
+			os.execute("killall -cont cvm")
 		end
 	)
 	obj:add(KEY_OUTOF_SCREEN_SAVER, nil, "Slider",
 		"toggle screen saver",
 		function()
-			util.sleep(3)
-			--os.execute("killall -stop cvm")
+			util.usleep(1500000)
+			os.execute("killall -stop cvm")
 			fb:setOrientation(Screen.kpv_rotation_mode)
 			Screen:restoreFromSavedBB()
 			fb:refresh(0)

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -138,8 +138,9 @@ function FileChooser:choose(ypos, height)
 					renderUtf8Text(fb.bb, 50, ypos + self.spacing*c, cface, self.files[i-#self.dirs], true)
 				end
 			end
+			all_page = math.ceil(self.items/perpage)
 			renderUtf8Text(fb.bb, 5, ypos + self.spacing * perpage + 42, fface,
-				"Page "..self.page.." of "..(math.floor(self.items / perpage)+1), true)
+				"Page "..self.page.." of "..all_page, true)
 			local msg = self.exception_message and self.exception_message:match("[^%:]+:%d+: (.*)") or "Path: "..self.path
 			self.exception_message = nil
 			renderUtf8Text(fb.bb, 5, ypos + self.spacing * (perpage+1) + 27, fface, msg, true)

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -262,7 +262,7 @@ function FileSearcher:choose(keywords)
 			-- draw footer
 			y = self.title_H + (self.spacing * self.perpage) + self.foot_H
 			x = (G_width / 2) - 50
-			all_page = (math.floor(self.items / self.perpage)+1)
+			all_page = math.ceil(self.items/self.perpage)
 			renderUtf8Text(fb.bb, x, y, fface,
 				"Page "..self.page.." of "..all_page, true)
 		end

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -18,6 +18,9 @@ if test "$1" == "--framework_stop"; then
 	/etc/init.d/framework stop
 fi
 
+# stop cvm
+killall -stop cvm
+
 # finally call reader
 ./reader.lua "$1" 2> /mnt/us/kindlepdfviewer/crash.log || cat /mnt/us/kindlepdfviewer/crash.log
 

--- a/reader.lua
+++ b/reader.lua
@@ -53,7 +53,7 @@ function openFile(filename)
 		if ok then
 			reader:loadSettings(filename)
 			page_num = reader:getLastPageOrPos()
-			reader:goto(tonumber(page_num))
+			reader:goto(tonumber(page_num), true)
 			reader_settings:savesetting("lastfile", filename)
 			return reader:inputLoop()
 		else

--- a/reader.lua
+++ b/reader.lua
@@ -169,6 +169,6 @@ fb:setOrientation(Screen.native_rotation_mode)
 
 input.closeAll()
 if util.isEmulated()==0 then
-	--os.execute("killall -cont cvm")
+	os.execute("killall -cont cvm")
 	os.execute('echo "send '..KEY_MENU..'" > /proc/keypad;echo "send '..KEY_MENU..'" > /proc/keypad')
 end

--- a/reader.lua
+++ b/reader.lua
@@ -54,7 +54,7 @@ function openFile(filename)
 			reader:loadSettings(filename)
 			page_num = reader:getLastPageOrPos()
 			reader:goto(tonumber(page_num), true)
-			reader_settings:savesetting("lastfile", filename)
+			reader_settings:saveSetting("lastfile", filename)
 			return reader:inputLoop()
 		else
 			InfoMessage:show("Error opening document.", 0)
@@ -160,7 +160,7 @@ end
 
 
 -- save reader settings
-reader_settings:savesetting("fontmap", Font.fontmap)
+reader_settings:saveSetting("fontmap", Font.fontmap)
 reader_settings:close()
 
 -- @TODO dirty workaround, find a way to force native system poll

--- a/screen.lua
+++ b/screen.lua
@@ -100,5 +100,9 @@ function Screen:getCurrentScreenBB()
 end
 
 function Screen:restoreFromBB(bb)
-	fb.bb:blitFullFrom(bb)
+	if bb then
+		fb.bb:blitFullFrom(bb)
+	else
+		debug("Got nil bb in restoreFromSavedBB!")
+	end
 end

--- a/settings.lua
+++ b/settings.lua
@@ -13,8 +13,12 @@ function DocSettings:readSetting(key)
 	return self.data[key]
 end
 
-function DocSettings:savesetting(key, value)
+function DocSettings:saveSetting(key, value)
 	self.data[key] = value
+end
+
+function DocSettings:delSetting(key)
+	self.data[key] = nil
 end
 
 function dump(data)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1341,7 +1341,7 @@ function UniReader:addJump(pageno)
 	-- build notes from TOC
 	local notes = self:getTocTitleOfCurrentPage()
 	if notes ~= "" then
-		notes = "in "..notes_to_add
+		notes = "in "..notes
 	end
 	-- create a head
 	jump_item = {
@@ -1389,7 +1389,7 @@ function UniReader:addBookmark(pageno)
 	-- build notes from TOC
 	local notes = self:getTocTitleOfCurrentPage()
 	if notes ~= "" then
-		notes = "in "..notes_to_add
+		notes = "in "..notes
 	end
 	mark_item = {
 		page = pageno,

--- a/unireader.lua
+++ b/unireader.lua
@@ -917,7 +917,6 @@ function UniReader:loadSettings(filename)
 			self.globalgamma = gamma
 		end
 
-		--@TODO clear obselate jump_stack  18.04 2012 (houqp)
 		local jump_history = self.settings:readSetting("jump_history")
 		if jump_history then
 			self.jump_history = jump_history
@@ -927,6 +926,17 @@ function UniReader:loadSettings(filename)
 
 		local bookmarks = self.settings:readSetting("bookmarks")
 		self.bookmarks = bookmarks or {}
+
+		-- clear obselate jumpstack settings
+		-- move jump_stack to bookmarks incase users used
+		-- it as bookmark feature before.
+		local jump_stack = self.settings:readSetting("jumpstack")
+		if jump_stack then
+			if #self.bookmarks == 0 then
+				self.bookmarks = jump_stack
+			end
+			self.settings:delSetting("jumpstack")
+		end
 
 		local highlight = self.settings:readSetting("highlight")
 		self.highlight = highlight or {}
@@ -949,7 +959,7 @@ function UniReader:getLastPageOrPos()
 end
 
 function UniReader:saveLastPageOrPos()
-	self.settings:savesetting("last_page", self.pageno)
+	self.settings:saveSetting("last_page", self.pageno)
 end
 
 -- guarantee that we have enough memory in cache
@@ -1762,13 +1772,13 @@ function UniReader:inputLoop()
 	end
 	if self.settings ~= nil then
 		self:saveLastPageOrPos()
-		self.settings:savesetting("gamma", self.globalgamma)
-		self.settings:savesetting("jump_history", self.jump_history)
-		self.settings:savesetting("bookmarks", self.bookmarks)
-		self.settings:savesetting("bbox", self.bbox)
-		self.settings:savesetting("globalzoom", self.globalzoom)
-		self.settings:savesetting("globalzoommode", self.globalzoommode)
-		self.settings:savesetting("highlight", self.highlight)
+		self.settings:saveSetting("gamma", self.globalgamma)
+		self.settings:saveSetting("jump_history", self.jump_history)
+		self.settings:saveSetting("bookmarks", self.bookmarks)
+		self.settings:saveSetting("bbox", self.bbox)
+		self.settings:saveSetting("globalzoom", self.globalzoom)
+		self.settings:saveSetting("globalzoommode", self.globalzoommode)
+		self.settings:saveSetting("highlight", self.highlight)
 		self:saveSpecialSettings()
 		self.settings:close()
 	end


### PR DESCRIPTION
#### Changes:
- jump stack is rewritten as jump history
  - show jump history `Shift`+`B`
  - go backward in history `Back`
  - go forward in history `Shift`+`Back`
- add bookmark feature
  - show bookmarks `B`
  - add current page to bookmarks `Alt`+`B`
- bug fix in filechooser and filesearcher
- bug fix in screen.lua
- fallback to stop framework on kpdf start, for screen saver fix
  This seems to be the only way to fix striped screen on screen saver so far. Leaving the framework running on background will randomly encounter a screen mess.
#### Notes about jump history:

Now we can keep going backward in history by press `Back` key. Vice versa with `Shift`+`Back`.

When we do a real jump (not regular page turn), the forward history will be cleaned up and a new head in history will be set.

Comments are welcome for the new implementation :)
#### PS:

DocSettings:savesetting has been renamed to DocSettings:saveSetting.
