### PR TITLE
fix bug in addJump and addBookmark 

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -108,10 +108,10 @@ static int getPageFromXPointer(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	const char *xpointer_str = luaL_checkstring(L, 2);
 
-	int page = 0;
+	int page = 1;
 	ldomXPointer xp = doc->dom_doc->createXPointer(lString16(xpointer_str));
 
-	page = doc->text_view->getBookmarkPage(xp);
+	page = doc->text_view->getBookmarkPage(xp) + 1;
 	lua_pushinteger(L, page);
 
 	return 1;
@@ -180,7 +180,7 @@ static int walkTableOfContent(lua_State *L, LVTocItem *toc, int *count) {
 		/* set subtable, Toc entry */
 		lua_newtable(L);
 		lua_pushstring(L, "page");
-		lua_pushnumber(L, toc_tmp->getPercent()); 
+		lua_pushnumber(L, toc_tmp->getPage()+1); 
 		lua_settable(L, -3);
 
 		lua_pushstring(L, "xpointer");
@@ -224,10 +224,6 @@ static int walkTableOfContent(lua_State *L, LVTocItem *toc, int *count) {
  *       title="chapter2"
  *    },
  * }
- *
- * Warnning: not like pdf or djvu support, page here refers to the
- * percent of height within the document, not the real page number.
- * We use page here just to keep consistent with other readers.
  *
  */
 static int getTableOfContent(lua_State *L) {
@@ -281,7 +277,7 @@ static int gotoPage(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	int pageno = luaL_checkint(L, 2);
 
-	doc->text_view->goToPage(pageno);
+	doc->text_view->goToPage(pageno-1);
 
 	return 0;
 }

--- a/crereader.lua
+++ b/crereader.lua
@@ -256,7 +256,7 @@ function CREReader:getTocTitleByPage(page_or_xpoint)
 end
 
 function CREReader:getTocTitleOfCurrentPage()
-	return self:getTocTitleByPage(self.percent)
+	return self:getTocTitleByPage(self.doc:getXPointer())
 end
 
 

--- a/crereader.lua
+++ b/crereader.lua
@@ -108,7 +108,7 @@ function CREReader:goto(pos, is_ignore_jump, pos_type)
 	if pos_type == "xpointer" then
 		self.doc:gotoXPointer(pos)
 		pos = self.doc:getCurrentPos()
-	else -- pos_type is PERCENT * 100
+	else -- pos_type is position within document
 		pos = math.min(pos, self.doc:getFullHeight() - height)
 		pos = math.max(pos, 0)
 		self.doc:gotoPos(pos)

--- a/crereader.lua
+++ b/crereader.lua
@@ -244,6 +244,17 @@ end
 ----------------------------------------------------
 -- TOC related methods
 ----------------------------------------------------
+function CREReader:getTocTitleByPage(page_or_xpoint)
+	local page = 1
+	-- tranform xpointer to page
+	if type(page_or_xpoint) == "string" then
+		page = self.doc:getPageFromXPointer(page_or_xpoint)
+	else
+		page = page_or_xpoint
+	end
+	return self:_getTocTitleByPage(page)
+end
+
 function CREReader:getTocTitleOfCurrentPage()
 	return self:getTocTitleByPage(self.percent)
 end

--- a/crereader.lua
+++ b/crereader.lua
@@ -134,9 +134,9 @@ function CREReader:goto(pos, is_ignore_jump, pos_type)
 	end
 	self.show_overlap = 0
 
-	if self.rcount == self.rcountmax then
+	if self.rcount >= self.rcountmax then
 		debug("full refresh")
-		self.rcount = 1
+		self.rcount = 0
 		fb:refresh(0)
 	else
 		debug("partial refresh")

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -191,7 +191,7 @@ function FileChooser:choose(ypos, height)
 					--[[
 					This might looks a little bit dirty for using callback.
 					But I cannot come up with a better solution for renewing
-					the height arguemtn according to screen rotation mode.
+					the height argument according to screen rotation mode.
 
 					The callback might also be useful for calling system
 					settings menu in the future.

--- a/reader.lua
+++ b/reader.lua
@@ -49,6 +49,7 @@ function openFile(filename)
 	end
 	if reader then
 		InfoMessage:show("Opening document, please wait... ", 0)
+		reader:preLoadSettings(filename)
 		local ok, err = reader:open(filename)
 		if ok then
 			reader:loadSettings(filename)

--- a/reader.lua
+++ b/reader.lua
@@ -33,7 +33,7 @@ longopts = {
 	password = "p",
 	goto = "g",
 	gamma = "G",
-	device = "d",
+	debug = "d",
 	help = "h"
 }
 
@@ -71,6 +71,7 @@ function showusage()
 	print("-p, --password=PASSWORD   set password for reading PDF document")
 	print("-g, --goto=page           start reading on page")
 	print("-G, --gamma=GAMMA         set gamma correction")
+	print("-d, --debug               start in debug mode")
 	print("                          (floating point notation, e.g. \"1.5\")")
 	print("-h, --help                show this usage help")
 	print("")
@@ -84,9 +85,17 @@ function showusage()
 	return
 end
 
-optarg, optind = alt_getopt.get_opts(ARGV, "p:G:hg:d:", longopts)
+optarg, optind = alt_getopt.get_opts(ARGV, "p:g:G:hg:dg:", longopts)
 if optarg["h"] then
 	return showusage()
+end
+
+if not optarg["d"] then
+	debug = function() end
+end
+
+if optarg["G"] ~= nil then
+	globalgamma = optarg["G"]
 end
 
 if util.isEmulated()==1 then
@@ -105,10 +114,6 @@ else
 		input.open("/dev/input/event2")
 		setK3Keycodes()
 	end
-end
-
-if optarg["G"] ~= nil then
-	globalgamma = optarg["G"]
 end
 
 fb = einkfb.open("/dev/fb0")

--- a/unireader.lua
+++ b/unireader.lua
@@ -907,11 +907,19 @@ function UniReader:initGlobalSettings(settings)
 	end
 end
 
+-- Method to load settings before document open
+function UniReader:preLoadSettings(filename)
+	self.settings = DocSettings:open(filename)
+
+	local cache_d_size = self.settings:readSetting("cache_document_size")
+	if cache_d_size then
+		self.cache_document_size = cache_d_size
+	end
+end
+
 -- This is a low-level method that can be shared with all readers.
 function UniReader:loadSettings(filename)
 	if self.doc ~= nil then
-		self.settings = DocSettings:open(filename,self.cache_document_size)
-
 		local gamma = self.settings:readSetting("gamma")
 		if gamma then
 			self.globalgamma = gamma

--- a/unireader.lua
+++ b/unireader.lua
@@ -1799,7 +1799,7 @@ function UniReader:addAllCommands()
 		"previous/next page",
 		function(unireader,keydef)
 			unireader:goto(
-			(keydef.keycode == KEY_PGBCK or Keydef.keycode == KEY_LPGBCK)
+			(keydef.keycode == KEY_PGBCK or keydef.keycode == KEY_LPGBCK)
 			and unireader:prevView() or unireader:nextView())
 		end)
 	self.commands:addGroup(MOD_ALT.."< >",{Keydef:new(KEY_PGBCK,MOD_ALT),Keydef:new(KEY_PGFWD,MOD_ALT)},

--- a/unireader.lua
+++ b/unireader.lua
@@ -1339,7 +1339,7 @@ end
 --]]
 function UniReader:addJump(pageno)
 	-- build notes from TOC
-	local notes = self:getTocTitleOfCurrentPage()
+	local notes = self:getTocTitleByPage(pageno)
 	if notes ~= "" then
 		notes = "in "..notes
 	end
@@ -1387,7 +1387,7 @@ function UniReader:addBookmark(pageno)
 		end
 	end
 	-- build notes from TOC
-	local notes = self:getTocTitleOfCurrentPage()
+	local notes = self:getTocTitleByPage(pageno)
 	if notes ~= "" then
 		notes = "in "..notes
 	end
@@ -1531,7 +1531,13 @@ function UniReader:fillToc()
 	self.toc = self.doc:getToc()
 end
 
+-- getTocTitleByPage wrapper, so specific reader
+-- can tranform pageno according its need
 function UniReader:getTocTitleByPage(pageno)
+	return self:_getTocTitleByPage(pageno)
+end
+
+function UniReader:_getTocTitleByPage(pageno)
 	if not self.toc then
 		-- build toc when needed.
 		self:fillToc()

--- a/unireader.lua
+++ b/unireader.lua
@@ -1318,7 +1318,7 @@ function UniReader:show(no)
 
 	if self.rcount >= self.rcountmax then
 		debug("full refresh")
-		self.rcount = 1
+		self.rcount = 0
 		fb:refresh(0)
 	else
 		debug("partial refresh")
@@ -1984,7 +1984,7 @@ function UniReader:addAllCommands()
 			fb:refresh(1)
 			fb.bb:invertRect(0, 0, 1, 1)
 			fb:refresh(0)
-			unireader.rcount = 1
+			unireader.rcount = 0
 		end)
 	self.commands:add(KEY_Z,nil,"Z",
 		"set crop mode",


### PR DESCRIPTION
Pointed out by @kljohann, thanks.
Now addJump and addBookmark get notes from specified pageno/xpointer instead of current page.
- add debug argument in reader.lua to suppress debug output.
- also fixed page number counting bugs in cre.cpp
- fix turn to previous page with KEY_LPGBCK
- fix bug in partial page refresh count
- load cache_document_size for each document
