### PR TITLE
fixes for mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ ifdef EMULATE_READER
 		     -DEMULATE_READER_W=$(EMULATE_READER_W) \
 		     -DEMULATE_READER_H=$(EMULATE_READER_H)
 	EMU_LDFLAGS?=$(shell sdl-config --libs)
+	ifeq "$(shell uname -s -m)" "Darwin x86_64"
+		EMU_LDFLAGS += -pagezero_size 10000 -image_base 100000000
+	endif
 else
 	CFLAGS+= $(ARM_CFLAGS)
 endif

--- a/pdf.c
+++ b/pdf.c
@@ -567,7 +567,7 @@ static int drawPage(lua_State *L) {
 }
 
 static int getCacheSize(lua_State *L) {
-	printf("## mupdf getCacheSize = %d\n", msize);
+	printf("## mupdf getCacheSize = %zu\n", msize);
 	lua_pushnumber(L, msize);
 	return 1;
 }


### PR DESCRIPTION
- per http://luajit.org/install.html, otherwise LuaJIT always fails
  to get desired memory chunk from mmap(2)
- appeases clang a little bit
