### PR TITLE
DjVu rendering mode and other changes.

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -400,8 +400,7 @@ static int drawPage(lua_State *L) {
 	DjvuPage *page = (DjvuPage*) luaL_checkudata(L, 1, "djvupage");
 	DrawContext *dc = (DrawContext*) luaL_checkudata(L, 2, "drawcontext");
 	BlitBuffer *bb = (BlitBuffer*) luaL_checkudata(L, 3, "blitbuffer");
-	int render_mode = (int) luaL_checkint(L, 6);
-	ddjvu_render_mode_t djvu_render_mode = render_mode;
+	ddjvu_render_mode_t djvu_render_mode = (int) luaL_checkint(L, 6);
 	unsigned char adjusted_low[16], adjusted_high[16];
 	int i, adjust_pixels = 0;
 	ddjvu_format_t *pixelformat;

--- a/djvu.c
+++ b/djvu.c
@@ -401,15 +401,9 @@ static int drawPage(lua_State *L) {
 	DrawContext *dc = (DrawContext*) luaL_checkudata(L, 2, "drawcontext");
 	BlitBuffer *bb = (BlitBuffer*) luaL_checkudata(L, 3, "blitbuffer");
 	int render_mode = (int) luaL_checkint(L, 6);
-	ddjvu_render_mode_t djvu_render_mode;
+	ddjvu_render_mode_t djvu_render_mode = render_mode;
 	unsigned char adjusted_low[16], adjusted_high[16];
 	int i, adjust_pixels = 0;
-
-	if (render_mode)
-		djvu_render_mode = DDJVU_RENDER_BLACK;
-	else
-		djvu_render_mode = DDJVU_RENDER_COLOR;
-
 	ddjvu_format_t *pixelformat;
 	ddjvu_rect_t pagerect, renderrect;
 	uint8_t *imagebuffer = NULL;

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -21,7 +21,47 @@ end
 function DJVUReader:adjustDjvuReaderCommand()
 	self.commands:del(KEY_J, MOD_SHIFT, "J")
 	self.commands:del(KEY_K, MOD_SHIFT, "K")
+	self.commands:add(KEY_R, nil, "R",
+		"colour/b&w/colouronly/maskonly/backg/foreg",
+		function(self)
+			self:cycle_render_mode()
+	end) 
 end
+
+-- cycle through all rendering modes supported by djvulibre:
+--  0	(color page or stencil)
+--  1	(stencil or color page)
+--  2	(color page or fail)
+--  3	(stencil or fail)
+--  4	(color background layer)
+--  5	(color foreground layer)
+--  Note that if the values in the definition of ddjvu_render_mode_t in djvulibre/libdjvu/ddjvuapi.h change,
+--  then we should update our values here also. This is a bit risky, but these values never change, so it should be ok :)
+function DJVUReader:cycle_render_mode()
+	self.render_mode = (self.render_mode + 1)%6
+	Debug("cycle_render_mode, render_mode=", self.render_mode)
+	self:clearCache()
+	self.doc:cleanCache()
+	local render_mode_name
+	if self.render_mode == 0 then
+		render_mode_name = "COLOUR"
+	elseif self.render_mode == 1 then
+		render_mode_name = "BLACK & WHITE"
+	elseif self.render_mode == 2 then
+		render_mode_name = "COLOUR ONLY"
+	elseif self.render_mode == 3 then
+		render_mode_name = "MASK ONLY"
+	elseif self.render_mode == 4 then
+		render_mode_name = "COLOUR BACKGROUND"
+	elseif self.render_mode == 5 then
+		render_mode_name = "COLOUR FOREGROUND"
+	else
+		render_mode_name = "UNKNOWN"
+	end
+	showInfoMsgWithDelay("("..self.render_mode..") "..render_mode_name, 1000, 1)
+	self:redrawCurrentPage()
+end
+
 
 
 ----------------------------------------------------

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -39,10 +39,10 @@ end
 --  then we should update our values here also. This is a bit risky, but these values never change, so it should be ok :)
 function DJVUReader:cycle_render_mode()
 	self.render_mode = (self.render_mode + 1)%6
-	Debug("cycle_render_mode, render_mode=", self.render_mode)
+	Debug("cycle_render_mode(), render_mode=", self.render_mode)
 	self:clearCache()
 	self.doc:cleanCache()
-	local render_mode_name
+	local render_mode_name = "UNKNOWN"
 	if self.render_mode == 0 then
 		render_mode_name = "COLOUR"
 	elseif self.render_mode == 1 then
@@ -55,14 +55,10 @@ function DJVUReader:cycle_render_mode()
 		render_mode_name = "COLOUR BACKGROUND"
 	elseif self.render_mode == 5 then
 		render_mode_name = "COLOUR FOREGROUND"
-	else
-		render_mode_name = "UNKNOWN"
 	end
 	showInfoMsgWithDelay("("..self.render_mode..") "..render_mode_name, 1000, 1)
 	self:redrawCurrentPage()
 end
-
-
 
 ----------------------------------------------------
 -- highlight support 

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -50,8 +50,8 @@ function DJVUReader:select_render_mode()
 		Debug("select_render_mode(), render_mode=", self.render_mode)
 		self:clearCache()
 		self.doc:cleanCache()
-		self:redrawCurrentPage()
 	end
+	self:redrawCurrentPage()
 end
 
 ----------------------------------------------------

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -22,7 +22,7 @@ function DJVUReader:adjustDjvuReaderCommand()
 	self.commands:del(KEY_J, MOD_SHIFT, "J")
 	self.commands:del(KEY_K, MOD_SHIFT, "K")
 	self.commands:add(KEY_R, nil, "R",
-		"colour/b&w/colouronly/maskonly/backg/foreg",
+		"select djvu page rendering mode",
 		function(self)
 			self:select_render_mode()
 	end) 

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -38,7 +38,7 @@ function DJVUReader:select_render_mode()
 			"COLOUR (works for both colour and b&w pages)",		--  0  (colour page or stencil)
 			"BLACK & WHITE (for b&w pages only, much faster)",	--  1  (stencil or colour page)
 			"COLOUR ONLY (slightly faster than COLOUR)",		--  2  (colour page or fail)
-			"MASK ONLY",										--  3  (stencil or fail)
+			"MASK ONLY (for b&w pages only)",					--  3  (stencil or fail)
 			"COLOUR BACKGROUND (show only background)",			--  4  (colour background layer)
 			"COLOUR FOREGROUND (show only foreground)"			--  5  (colour foreground layer)
 			},
@@ -71,4 +71,3 @@ function DJVUReader:invertTextYAxel(pageno, text_table)
 	end
 	return text_table
 end
-

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -24,40 +24,34 @@ function DJVUReader:adjustDjvuReaderCommand()
 	self.commands:add(KEY_R, nil, "R",
 		"colour/b&w/colouronly/maskonly/backg/foreg",
 		function(self)
-			self:cycle_render_mode()
+			self:select_render_mode()
 	end) 
 end
 
--- cycle through all rendering modes supported by djvulibre:
---  0	(color page or stencil)
---  1	(stencil or color page)
---  2	(color page or fail)
---  3	(stencil or fail)
---  4	(color background layer)
---  5	(color foreground layer)
---  Note that if the values in the definition of ddjvu_render_mode_t in djvulibre/libdjvu/ddjvuapi.h change,
---  then we should update our values here also. This is a bit risky, but these values never change, so it should be ok :)
-function DJVUReader:cycle_render_mode()
-	self.render_mode = (self.render_mode + 1)%6
-	Debug("cycle_render_mode(), render_mode=", self.render_mode)
-	self:clearCache()
-	self.doc:cleanCache()
-	local render_mode_name = "UNKNOWN"
-	if self.render_mode == 0 then
-		render_mode_name = "COLOUR"
-	elseif self.render_mode == 1 then
-		render_mode_name = "BLACK & WHITE"
-	elseif self.render_mode == 2 then
-		render_mode_name = "COLOUR ONLY"
-	elseif self.render_mode == 3 then
-		render_mode_name = "MASK ONLY"
-	elseif self.render_mode == 4 then
-		render_mode_name = "COLOUR BACKGROUND"
-	elseif self.render_mode == 5 then
-		render_mode_name = "COLOUR FOREGROUND"
+-- select the rendering mode from those supported by djvulibre.
+-- Note that if the values in the definition of ddjvu_render_mode_t in djvulibre/libdjvu/ddjvuapi.h change,
+-- then we should update our values here also. This is a bit risky, but these values never change, so it should be ok :)
+function DJVUReader:select_render_mode()
+	local mode_menu = SelectMenu:new{
+		menu_title = "Select DjVu page rendering mode",
+		item_array = {
+			"COLOUR (works for both colour and b&w pages)",		--  0  (colour page or stencil)
+			"BLACK & WHITE (for b&w pages only, much faster)",	--  1  (stencil or colour page)
+			"COLOUR ONLY (slightly faster than COLOUR)",		--  2  (colour page or fail)
+			"MASK ONLY",										--  3  (stencil or fail)
+			"COLOUR BACKGROUND (show only background)",			--  4  (colour background layer)
+			"COLOUR FOREGROUND (show only foreground)"			--  5  (colour foreground layer)
+			},
+		current_entry = self.render_mode,
+	}
+	local mode = mode_menu:choose(0, fb.bb:getHeight()) 
+	if mode then
+		self.render_mode = mode - 1
+		Debug("select_render_mode(), render_mode=", self.render_mode)
+		self:clearCache()
+		self.doc:cleanCache()
+		self:redrawCurrentPage()
 	end
-	showInfoMsgWithDelay("("..self.render_mode..") "..render_mode_name, 1000, 1)
-	self:redrawCurrentPage()
 end
 
 ----------------------------------------------------

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -403,11 +403,9 @@ function FileChooser:addAllCommands()
 			local oldname = self:FullFileName()
 			if oldname then
 				local name_we = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
-				local ext = string.lower(string.match(oldname, ".+%.([^.]+)") or "")
-				name_we = string.sub(name_we,1,-2-string.len(ext))
 				local newname = InputBox:input(0, 0, "New filename:", name_we)
 				if newname then
-					newname = self.path.."/"..newname..'.'..ext
+					newname = self.path.."/"..newname
 					os.rename(oldname, newname)
 					os.rename(DocToHistory(oldname), DocToHistory(newname))
 					self:setPath(self.path)

--- a/unireader.lua
+++ b/unireader.lua
@@ -34,9 +34,9 @@ UniReader = {
 	-- gamma setting:
 	globalgamma = 1.0,   -- GAMMA_NO_GAMMA
 
-	-- rendering mode toggle (used in djvu.c:drawPage())
-	-- if set to 1 render in BLACK & WHITE, otherwise COLOR
-	render_mode = 1,
+	-- DjVu page rendering mode (used in djvu.c:drawPage())
+	-- See comments in djvureader.lua:DJVUReader:cycle_render_mode()
+	render_mode = 0, -- COLOUR
 
 	-- cached tile size
 	fullwidth = 0,
@@ -1576,16 +1576,6 @@ function UniReader:modifyGamma(factor)
 	self:redrawCurrentPage()
 end
 
--- toggle rendering mode between colour (0) and b&w (1)
-function UniReader:toggle_render_mode()
-	Debug("toggle_render_mode, render_mode=", self.render_mode)
-	self.render_mode = 1 - self.render_mode
-	self:clearCache()
-	self.doc:cleanCache()
-	showInfoMsgWithDelay("New render_mode = "..self.render_mode, 1000, 1)
-	self:redrawCurrentPage()
-end
-
 -- adjust zoom state and trigger re-rendering
 function UniReader:setglobalzoom_mode(newzoommode)
 	if self.globalzoom_mode ~= newzoommode then
@@ -2216,11 +2206,6 @@ function UniReader:addAllCommands()
 			else
 				self:redrawCurrentPage()
 			end
-		end)
-	self.commands:add(KEY_R, nil, "R",
-		"toggle rendering mode: b&w/colour",
-		function(unireader)
-			unireader:toggle_render_mode()
 		end)
 	self.commands:add(KEY_R, MOD_SHIFT, "R",
 		"manual full screen refresh",

--- a/unireader.lua
+++ b/unireader.lua
@@ -35,7 +35,7 @@ UniReader = {
 	globalgamma = 1.0,   -- GAMMA_NO_GAMMA
 
 	-- DjVu page rendering mode (used in djvu.c:drawPage())
-	-- See comments in djvureader.lua:DJVUReader:cycle_render_mode()
+	-- See comments in djvureader.lua:DJVUReader:select_render_mode()
 	render_mode = 0, -- COLOUR
 
 	-- cached tile size

--- a/unireader.lua
+++ b/unireader.lua
@@ -1015,6 +1015,7 @@ function UniReader:loadSettings(filename)
 
 		self.globalzoom = self.settings:readSetting("globalzoom") or 1.0
 		self.globalzoom_mode = self.settings:readSetting("globalzoom_mode") or -1
+		self.render_mode = self.settings:readSetting("render_mode") or 0
 
 		self:loadSpecialSettings()
 		return true
@@ -1994,6 +1995,7 @@ function UniReader:inputLoop()
 		self.settings:saveSetting("globalzoom", self.globalzoom)
 		self.settings:saveSetting("globalzoom_mode", self.globalzoom_mode)
 		self.settings:saveSetting("highlight", self.highlight)
+		self.settings:saveSetting("render_mode", self.render_mode)
 		self:saveSpecialSettings()
 		self.settings:close()
 	end


### PR DESCRIPTION
1. djvu.c Remove the local variable render_mode from drawPage() function as it is no longer necessary (because Lua value of render_mode matches the "physical" djvu page rendering mode value).
2. djvureader.lua Implement DjVu page rendering mode selection as a menu.
3. unireader.lua Change the default value of render_mode to COLOUR (to cover ALL DjVu files, leaving it up to the user to optimize it specifically for B&W files if she chooses to). Also, save/restore the value of render_mode setting.
4. filechooser.lua Allow renaming the full filename, together with extension. Now, I personally think it should work like this, but if the Master Architects of kindlepdfviewer disagree, this change should not be admitted into the master tree (but I have no way of removing it from this pull request).
