### PR TITLE
Bugfix: moving files to/from clipboard works now.

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -492,7 +492,6 @@ function FileChooser:addAllCommands()
 				lfs.mkdir(self.clipboard)
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
 				os.rename(file, self.clipboard.."/"..fn)
-				Debug("os.rename("..file..","..self.clipboard.."/"..fn)
 				os.rename(DocToHistory(file), DocToHistory(self.clipboard.."/"..fn))
 				InfoMessage:show("File moved to clipboard ", 0)
 				self:setPath(self.path)

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -490,8 +490,9 @@ function FileChooser:addAllCommands()
 			local file = self:FullFileName()
 			if file then
 				lfs.mkdir(self.clipboard)
-				os.rename(file, self.clipboard.."/"..file)
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
+				os.rename(file, self.clipboard.."/"..fn)
+				Debug("os.rename("..file..","..self.clipboard.."/"..fn)
 				os.rename(DocToHistory(file), DocToHistory(self.clipboard.."/"..fn))
 				InfoMessage:show("File moved to clipboard ", 0)
 				self:setPath(self.path)


### PR DESCRIPTION
In the call to os.rename() we should pass the base filename, not the full pathname as the target, otherwise it will fail. Tested before the fix: Shift-X to move the file to clipboard ---> nothing is there, clipboard is empty. After the fix: Shift-X moves the file and Shift-V pastes it where we want it.
