### PR TITLE
Bugfix: screen refresh needed on exit from zoom mode menu.

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -2123,11 +2123,11 @@ function UniReader:addAllCommands()
 				current_entry = - unireader.globalzoom_mode
 				}
 			local re = zoom_menu:choose(0, G_height)
-			if not re or re==1 or re==8 or re==9 then -- if not proper zoom-mode
-				unireader:redrawCurrentPage()
-			else
+			if re and re ~= 1 and re ~= 8 and re ~= 9 then -- if proper zoom-mode
+				Debug("setting zoom mode re=" .. re)
 				unireader:setglobalzoom_mode(1-re)
 			end
+			unireader:redrawCurrentPage()
 		end)
 	-- to leave or to erase 8 hotkeys switching zoom-mode directly?
 

--- a/unireader.lua
+++ b/unireader.lua
@@ -2124,7 +2124,6 @@ function UniReader:addAllCommands()
 				}
 			local re = zoom_menu:choose(0, G_height)
 			if re and re ~= 1 and re ~= 8 and re ~= 9 then -- if proper zoom-mode
-				Debug("setting zoom mode re=" .. re)
 				unireader:setglobalzoom_mode(1-re)
 			end
 			unireader:redrawCurrentPage()


### PR DESCRIPTION
We need to redraw the screen on any return from the zoom mode menu selection, otherwise the user gets the impression that the program hangs (I just got one such report from eLINK2gl) if the user selects the mode matching (or "effectively" matching) the current one.
