### PR TITLE
 fix crash on documents without TOC

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1738,9 +1738,11 @@ function UniReader:showToc()
 			prev = k
 			prev_depth = self.toc[prev].depth
 		end -- for k,v in ipairs(self.toc)
-		self.toc_curidx_to_x = self.toc_children[0]
-		for i=1,#self.toc_children[0] do
-			table.insert(self.toc_cview, self.toc_xview[self.toc_children[0][i]])
+		if ( self.toc_children[0] ) then
+			self.toc_curidx_to_x = self.toc_children[0]
+			for i=1,#self.toc_children[0] do
+				table.insert(self.toc_cview, self.toc_xview[self.toc_children[0][i]])
+			end
 		end
 	end
 


### PR DESCRIPTION
Showing TOC on documents without one results in following error:

lua config error: ./unireader.lua:1742: attempt to get length of a nil value
