### PR TITLE
use ldomDocCache::init to cache crengine DOM

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -546,6 +546,8 @@ int luaopen_cre(lua_State *L) {
 	/* initialize font manager for CREngine */
 	InitFontManager(lString8());
 
+	ldomDocCache::init(lString16("./cr3cache"), 100);
+
 #ifdef DEBUG_CRENGINE
 	CRLog::setStdoutLogger();
 	CRLog::setLogLevel(CRLog::LL_DEBUG);


### PR DESCRIPTION
This should improve performance of crengine #206
