### PR TITLE
fileinfo doesn't reset results

### DIFF
--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -32,6 +32,7 @@ end
 
 function FileInfo:init(path, fname)
 	self.pathfile = path.."/"..fname
+	self.result = {}
 	-- add commands only once
 	if not self.commands then
 		self:addAllCommands()


### PR DESCRIPTION
This affects multiple entry into fileinfo which just accumulate
information, eventually scrolling off screen
