### PR TITLE
Slight tidy up to the fix for \#257

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -364,21 +364,20 @@ function FileChooser:addAllCommands()
 			local pos = self.perpage*(self.page-1)+self.current
 			local folder = self.dirs[pos]
 			if folder == ".." then
-				showInfoMsgWithDelay("<UP-DIR> can not be deleted! ",2000,1)
+				showInfoMsgWithDelay(".. cannot be deleted! ",2000,1)
 			elseif folder then
-				InfoMessage:show("Press \'Y\' to confirm deleting... ",0)
+				InfoMessage:show("Press \'Y\' to confirm",0)
 				if self:ReturnKey() == KEY_Y then
 					if lfs.rmdir(self.path.."/"..folder) then
-						self.pagedirty = true
 						table.remove(self.dirs, offset)
 						self.items = self.items - 1
 						self.current = self.current - 1
 					else
-						showInfoMsgWithDelay("This folder can not be deleted! ",2000,1)
+						showInfoMsgWithDelay("Cannot be deleted!",2000,1)
 					end
 				end
 			else
-				InfoMessage:show("Press \'Y\' to confirm deleting... ",0)
+				InfoMessage:show("Press \'Y\' to confirm",0)
 				if self:ReturnKey() == KEY_Y then
 					pos = pos - #self.dirs
 					local fullpath = self.path.."/"..self.files[pos]
@@ -390,9 +389,9 @@ function FileChooser:addAllCommands()
 					table.remove(self.files, pos)
 					self.items = self.items - 1
 					self.current = self.current - 1
-					self.pagedirty = true
 				end
 			end -- if folder == ".."
+			self.pagedirty = true
 		end -- function
 	)
 	-- make renaming flexible: it either keeps old extention (BEGINNERS_MODE) or

--- a/unireader.lua
+++ b/unireader.lua
@@ -1738,7 +1738,7 @@ function UniReader:showToc()
 			prev = k
 			prev_depth = self.toc[prev].depth
 		end -- for k,v in ipairs(self.toc)
-		if ( self.toc_children[0] ) then
+		if (self.toc_children[0]) then
 			self.toc_curidx_to_x = self.toc_children[0]
 			for i=1,#self.toc_children[0] do
 				table.insert(self.toc_cview, self.toc_xview[self.toc_children[0][i]])
@@ -1747,7 +1747,8 @@ function UniReader:showToc()
 	end
 
 	if #self.toc == 0 then
-		return showInfoMsgWithDelay("No Table of Contents", 1500, 1)
+		showInfoMsgWithDelay("No Table of Contents", 1500, 1)
+		return self:redrawCurrentPage()
 	end
 
 	self.toc_curitem = self:findTOCpos()


### PR DESCRIPTION
For documents with no TOC we need to redraw the screen after showing the "No Table of Contents" message, otherwise the message "Retrieving TOC..." will stay on indefinitely.
