### PR TITLE
Shorten the message about opening the document.

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -43,7 +43,7 @@ function openFile(filename)
 
 	reader = ext:getReader(file_type)
 	if reader then
-		InfoMessage:show("Opening document, please wait... ", 0)
+		InfoMessage:show("Opening document... ", 0)
 		reader:preLoadSettings(filename)
 		local ok, err = reader:open(filename)
 		if ok then


### PR DESCRIPTION
Shorten the message about opening the document to make it displayed at all.
(sorry for the very trivial change).

I learned how to use git branches properly and now I have interesting branches like "experimental", "filemanager" and "reflow" which have much bigger, but still very buggy and unfinished pieces of work.
