### PR TITLE
TOC cleanup in crengine.lua

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -346,7 +346,7 @@ function CREReader:gotoPrevNextTocEntry(direction)
 		self:fillToc()
 	end
 	if #self.toc == 0 then
-		showInfoMsgWithDelay("This document does not have a TOC.", 2000, 1)
+		showInfoMsgWithDelay("No Table of Contents", 1500, 1)
 		return
 	end
 	-- search for current TOC-entry
@@ -442,7 +442,6 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			Screen:screenRotate("anticlockwise")
 			G_width, G_height = fb:getSize()
-			self:fillToc()
 			self:goto(prev_xpointer, nil, "xpointer")
 			self.pos = self.doc:getCurrentPos()
 		end
@@ -455,7 +454,6 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			Screen:screenRotate("clockwise")
 			G_width, G_height = fb:getSize()
-			self:fillToc()
 			self:goto(prev_xpointer, nil, "xpointer")
 			self.pos = self.doc:getCurrentPos()
 		end
@@ -507,7 +505,6 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:zoomFont(delta)
 			self:goto(prev_xpointer, nil, "xpointer")
-			self:fillToc()
 		end
 	)
 	self.commands:addGroup(MOD_ALT.."< >",{
@@ -528,7 +525,6 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:setDefaultInterlineSpace(self.line_space_percent)
 			self:goto(prev_xpointer, nil, "xpointer")
-			self:fillToc()
 		end
 	)
 	local numeric_keydefs = {}
@@ -585,7 +581,6 @@ function CREReader:adjustCreReaderCommands()
 				InfoMessage:show("Redrawing with "..face_list[item_no], 0)
 				self.doc:setFontFace(face_list[item_no])
 				self.font_face = face_list[item_no]
-				self:fillToc()
 			end
 			self:goto(prev_xpointer, nil, "xpointer")
 		end
@@ -608,7 +603,6 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:toggleFontBolder()
 			self:goto(prev_xpointer, nil, "xpointer")
-			self:fillToc()
 		end
 	)
 	self.commands:add(KEY_B, MOD_ALT, "B",


### PR DESCRIPTION
1. Shorten the "This document does not have a TOC." message to "No Table of Contents" in order to make it visible.
2. Get rid of all the calls to self:fillToc() from the places in the code which cannot affect TOC, such as rotation, font change and interlinear spacing change. I assume the reason for these calls is that they are needed in the original CoolReader application (because there the TOC displays the virtual "page numbers" which can change after any of these operations) and were brought over to our crengine.lua during the port.
