### PR TITLE
Calculator: make it more robust.

### DIFF
--- a/inputbox.lua
+++ b/inputbox.lua
@@ -604,8 +604,7 @@ function InputBox:ModeDependentCommands()
 					showInfoMsgWithDelay("No input ", 1000, 1)
 				else
 					local s = self:PrepareStringToCalc()
-					if pcall(function () f = assert(loadstring("r = tostring("..s..")")) end) then
-						f()
+					if pcall(function () f = assert(loadstring("r = tostring("..s..")")) end) and pcall(f) then
 						self:clearText()
 						self.cursor:clear()
 						for i=1, string.len(r) do


### PR DESCRIPTION
Previously it was very easy to crash the application by entering invalid input into calculator, for example
things like these: ")(", "inf/0", "f()", etc. By using Lua pcall() function to execute not only the construction of
the expression, but also the calculation of the final result, the calculator is made more robust and safe-guarded from such crashes.
