### PR TITLE
Minor changes to djvu and filesearcher.

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -79,9 +79,9 @@ static int openDocument(lua_State *L) {
 	luaL_getmetatable(L, "djvudocument");
 	lua_setmetatable(L, -2);
 
-	doc->context = ddjvu_context_create("DJVUReader");
+	doc->context = ddjvu_context_create("kindlepdfviewer");
 	if (! doc->context) {
-		return luaL_error(L, "cannot create context.");
+		return luaL_error(L, "cannot create context");
 	}
 
 	printf("## cache_size = %d\n", cache_size);
@@ -91,12 +91,12 @@ static int openDocument(lua_State *L) {
 	while (! ddjvu_document_decoding_done(doc->doc_ref))
 		handle(L, doc->context, True);
 	if (! doc->doc_ref) {
-		return luaL_error(L, "cannot open DJVU file <%s>", filename);
+		return luaL_error(L, "cannot open DjVu file <%s>", filename);
 	}
 
 	doc->pixelformat = ddjvu_format_create(DDJVU_FORMAT_GREY8, 0, NULL);
 	if (! doc->pixelformat) {
-		return luaL_error(L, "cannot create DJVU pixelformat for <%s>", filename);
+		return luaL_error(L, "cannot create DjVu pixelformat for <%s>", filename);
 	}
 	ddjvu_format_set_row_order(doc->pixelformat, 1);
 	ddjvu_format_set_y_direction(doc->pixelformat, 1);

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -47,9 +47,7 @@ function DJVUReader:select_render_mode()
 	local mode = mode_menu:choose(0, fb.bb:getHeight()) 
 	if mode then
 		self.render_mode = mode - 1
-		Debug("select_render_mode(), render_mode=", self.render_mode)
 		self:clearCache()
-		self.doc:cleanCache()
 	end
 	self:redrawCurrentPage()
 end

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -275,7 +275,7 @@ function FileSearcher:choose(keywords)
 			fb.bb:paintRect(0, 0, G_width, G_height, 0)
 
 			-- draw menu title
-			DrawTitle("Search Results for \'"..string.upper(self.keywords).."\'",self.margin_H,0,self.title_H,3,tface)
+			DrawTitle("Search Results for \'"..string.upper(self.keywords).."\'".." ("..tostring(self.items).." hits)",self.margin_H,0,self.title_H,3,tface)
 			-- draw results
 			local c
 			if self.items == 0 then -- nothing found

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -64,7 +64,7 @@ function FileSearcher:setSearchResult(keywords)
 		self.result = self.files
 	else
 		for __,f in pairs(self.files) do
-			if string.find(string.lower(f.name), keywords) then
+			if string.find(string.lower(f.name), string.lower(keywords)) then
 				table.insert(self.result, f)
 			end
 		end

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -275,7 +275,7 @@ function FileSearcher:choose(keywords)
 			fb.bb:paintRect(0, 0, G_width, G_height, 0)
 
 			-- draw menu title
-			DrawTitle("Search Results for \'"..string.upper(self.keywords).."\'".." ("..tostring(self.items).." hits)",self.margin_H,0,self.title_H,3,tface)
+			DrawTitle("Search Results for \'"..self.keywords.."\'".." ("..tostring(self.items).." hits)",self.margin_H,0,self.title_H,3,tface)
 			-- draw results
 			local c
 			if self.items == 0 then -- nothing found

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -219,7 +219,7 @@ function FileSearcher:addAllCommands()
 		function(self)
 			file_entry = self.result[self.perpage*(self.page-1)+self.current]
 			local file_to_del = file_entry.dir .. "/" .. file_entry.name
-			InfoMessage:show("Press \'Y\' to confirm deleting... ",0)
+			InfoMessage:show("Press \'Y\' to confirm... ",0)
 			while true do
 				ev = input.saveWaitForEvent()
 				ev.code = adjustKeyEvents(ev)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1483,6 +1483,8 @@ end
 -- change current page and cache next page after rendering
 function UniReader:goto(no, is_ignore_jump)
 	if no < 1 or no > self.doc:getPages() then
+		-- may be reached by following TOC entry pointing to external file.
+		self:redrawCurrentPage()
 		return
 	end
 


### PR DESCRIPTION
1. Change the name of DjVu context created to "kpdfview" as it is common practice to call the context the name of the program. (though I understand the reason for the current name, i.e. pointing to Lua object DJVUReader)
2. When changing DjVu rendering mode we don't need to clear the djvulibre document cache, only the internal tile cache.
3. In file searcher: a) show the number of hits, b) show the actual pattern entered, c) shorten the delete confirmation message to make it visible, d) make the search case-insensitive (so searching for "DJVU" will find djvu files, previously it didn't).
