### PR TITLE
Stop writing battery info messages to crash.log every few seconds.

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -57,7 +57,7 @@ end
 function BatteryLevel()
 	local fn, battery = "/tmp/kindle-battery-info", "?"
 	-- NuPogodi, 18.05.12: This command seems to work even without Amazon Kindle framework 
-	os.execute("gasgauge-info -s > "..fn)
+	os.execute("gasgauge-info -s 2> /dev/null > "..fn)
 	if io.open(fn,"r") then
 		for lines in io.lines(fn) do battery = " " .. lines end
 	else


### PR DESCRIPTION
We only need standard output of `gasgauge-info -s` command, so standard error can be safely redirected to /dev/null and thus prevents those messages in crash.log every time the user presses "Menu" or does anything else that invokes the BatteryLevel() function.
