### PR TITLE
Simple cleanups...

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -532,7 +532,7 @@ function FileChooser:addAllCommands()
 			self.pagedirty = true
 		end
 	)
-	self.commands:add({KEY_BACK, KEY_HOME}, nil, "Back",
+	self.commands:add(KEY_HOME, nil, "Back",
 		"exit",
 		function(self)
 			return "break"

--- a/filehistory.lua
+++ b/filehistory.lua
@@ -199,6 +199,10 @@ function FileHistory:addAllCommands()
 	self.commands:add({KEY_ENTER, KEY_FW_PRESS}, nil, "Enter",
 		"open selected item",
 		function(self)
+			if #self.result == 0 then
+				showInfoMsgWithDelay("No files to open", 1500, 1)
+				return
+			end
 			file_entry = self.result[self.perpage*(self.page-1)+self.current]
 			file_full_path = file_entry.dir .. "/" .. file_entry.name
 

--- a/unireader.lua
+++ b/unireader.lua
@@ -970,7 +970,7 @@ function UniReader:loadSettings(filename)
 		if self.highlight.to_fix ~= nil then
 			for _,fix_item in ipairs(self.highlight.to_fix) do
 				if fix_item == "djvu invert y axle" then
-					InfoMessage:show("Updating HighLight data...", 1)
+					Debug("Updating HighLight data...")
 					for pageno,text_table in pairs(self.highlight) do
 						if type(pageno) == "number" then
 							text_table = self:invertTextYAxel(pageno, text_table)

--- a/unireader.lua
+++ b/unireader.lua
@@ -386,7 +386,7 @@ end
 function UniReader:startHighLightMode()
 	local t = self:getText(self.pageno)
 	if not t or #t == 0 then
-		showInfoMsgWithDelay("No text available for highlight", 2000, 1);
+		showInfoMsgWithDelay("No text available", 1000, 1);
 		return nil
 	end
 
@@ -397,7 +397,7 @@ function UniReader:startHighLightMode()
 			end
 		end
 
-		showInfoMsgWithDelay("No visible text for highlight", 2000, 1);
+		showInfoMsgWithDelay("No visible text", 1000, 1);
 		Debug("_findFirstWordInView none found in", t)
 
 		return nil


### PR DESCRIPTION
... which I didn't want to get mixed up with the more serious changes to follow in the next pull request. In this one we have just:
1. Don't exit on pressing "Back" in filemanager
2. Make info messages about highlight short enough to be displayable.
3. Change "Updating HighLight data..." to Debug() as it is non-blocking and irrelevant to the user (especially because it is displayed on files which have no highlight data anyway and this may cause confusion).
4. Don't crash when user presses ENTER or FW select buttons on empty history, just display an appropriate (short) message.
