### PR TITLE
Report the amount of free disk space in file info.

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -532,7 +532,7 @@ function FileChooser:addAllCommands()
 			self.pagedirty = true
 		end
 	)
-	self.commands:add(KEY_HOME, nil, "Back",
+	self.commands:add(KEY_HOME, nil, "Home",
 		"exit",
 		function(self)
 			return "break"

--- a/util.c
+++ b/util.c
@@ -17,6 +17,7 @@
 */
 
 #include <sys/time.h>
+#include <sys/statvfs.h>
 #include <unistd.h>
 
 #include "util.h"
@@ -41,10 +42,18 @@ static int util_usleep(lua_State *L) {
 	return 0;
 }
 
+static int util_df(lua_State *L) {
+	char *path = luaL_checkstring(L, 1);
+	struct statvfs vfs;
+	statvfs(path, &vfs);
+	lua_pushnumber(L, (double)vfs.f_bfree * (double)vfs.f_bsize);
+	return 1;
+}
+
 /* Turn UTF-8 char code to Unicode */
 static int utf8charcode(lua_State *L) {
 	size_t len;
-	const char* utf8char = luaL_checklstring(L, 1, &len);
+	const char *utf8char = luaL_checklstring(L, 1, &len);
 	int c;
 	if(len == 1) {
 		c = utf8char[0] & 0x7F; /* should not be needed */
@@ -75,6 +84,7 @@ static const struct luaL_Reg util_func[] = {
 	{"usleep", util_usleep},
 	{"utf8charcode", utf8charcode},
 	{"isEmulated", isEmulated},
+	{"df", util_df},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
I think it is useful to know the amount of free disk space from within KPV's file manager, especially for deciding whether to remove the current file or not. So I implemented a new function util.df which resides in util.c and internally calls statvfs(2) system call, returning the amount of free disk space in a specified filesystem in bytes.

Also, in this pull request a cleanup from the previous commit of making "Home" the only exit key from filemanager --- I forgot to mention this in the helppage so it still said "Back: exit".
