### PR TITLE
Fix for the crash mentioned in issue #295

### DIFF
--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -84,10 +84,10 @@ function FileInfo:init(path, fname)
 	local history = DocToHistory(self.pathfile)
 	local file, msg = io.open(history, "r")
 	if not file then 
-		info_entry = {dir = "Last Read", name = "Never"}
+		info_entry = {dir = "Last read", name = "Never"}
 		table.insert(self.result, info_entry)
 	else
-		info_entry = {dir = "Last Read", name = FileInfo:FileCreated(history, "change")}
+		info_entry = {dir = "Last read", name = FileInfo:FileCreated(history, "change")}
 		table.insert(self.result, info_entry)
 		local file_type = string.lower(string.match(self.pathfile, ".+%.([^.]+)"))
 		local to_search, add, factor = "[\"last_percent\"]", "%", 100

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -73,9 +73,11 @@ function FileInfo:init(path, fname)
 
 	info_entry = {dir = "Free space", name = FileInfo:FormatSize(util.df("."))}
 	table.insert(self.result, info_entry)
-	info_entry = {dir = "Created", name = FileInfo:FileCreated(self.pathfile, "change")}
+	info_entry = {dir = "Status changed", name = FileInfo:FileCreated(self.pathfile, "change")}
 	table.insert(self.result, info_entry)
 	info_entry = {dir = "Modified", name = FileInfo:FileCreated(self.pathfile, "modification")}
+	table.insert(self.result, info_entry)
+	info_entry = {dir = "Accessed", name = FileInfo:FileCreated(self.pathfile, "access")}
 	table.insert(self.result, info_entry)
 
 	-- if the document was already opened

--- a/unireader.lua
+++ b/unireader.lua
@@ -1958,7 +1958,6 @@ function UniReader:showHighLight()
 			if #self.highlight[hpage] == 0 then
 				table.remove(self.highlight, hpage)
 			end
-			table.remove(highlight_page, item_no)
 			table.remove(menu_items, item_no)
 			if #menu_items == 0 then
 				return self:redrawCurrentPage()


### PR DESCRIPTION
When deleting multiple highlights on a page (or more than one page) via list the viewer would crash depending on the order in which they are deleted. This patch fixes the problem.

Also, in the file info I changed "Created" to "Status changed" (for that is what ctime means in Unix) and added a field "Accessed" (showing atime) for completeness.
