### PR TITLE
Fix a crash in getDiskSizeInfo() (in emulator) and use util.df function.

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -35,18 +35,15 @@ function CREReader:init()
 		self.default_font = default_font
 	end
 end
+
 -- inspect the zipfile content
 function CREReader:ZipContentExt(fname)
 	local i, s = 1
-	local tmp = assert(io.popen('unzip -l \"'..fname..'\"', "r"))
-	while tmp do
-		s = tmp:read("*line")
-		if i > 3 then tmp:close(); break; end
-		i = i + 1
-	end
+	local tmp = assert(io.popen('unzip -l \"'..fname..'\" | head -4 | tail -1', "r"))
+	s = tmp:read("*line")
+	tmp:close()
 	return s and string.lower(string.match(s, ".+%.([^.]+)"))
 end
-
 
 -- open a CREngine supported file and its settings store
 function CREReader:open(filename)

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -46,15 +46,8 @@ function getUnpackedZipSize(zipfile)
 end
 
 function getDiskSizeInfo()
-	local s = {}
-	local tmp = assert(io.popen('df /mnt/us/ | tail -1', "r"))
-	local output = assert(tmp:read("*line"))
-	for w in string.gmatch(output, "%d+") do 
-		s[#s+1] = tonumber(w)*1024 -- to return in bytes
-	end
-	tmp:close()
-	if #s < 3 then return nil end
-	return { total = s[1], used = s[2], free = s[3] }
+	local t, f = util.df(".")
+	return { total = t, free = f }
 end
 
 function FileInfo:formatDiskSizeInfo()

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -62,9 +62,7 @@ function FileInfo:getFolderContent()
 	InfoMessage:show("Scanning folder...", 1)
 	local tmp = assert(io.popen('du -a \"'..self.pathfile..'\"', "r"))
 	local dirs, files, books, size, name, output, ftype, j = -1, 0, 0, 0
-	while true do
-		output = tmp:read("*line")
-		if not output then break end
+	for output in tmp:lines() do
 		j = output:find("/")
 		name = output:sub(j, -1)
 		size = tonumber(output:sub(1, j-1)) -- in kB

--- a/unireader.lua
+++ b/unireader.lua
@@ -1642,14 +1642,22 @@ function UniReader:fillToc()
 			end
 		elseif (v.depth == prev_depth) then --> k and prev are siblings
 			parent[k] = parent[prev]
-			table.insert(self.toc_children[parent[k]], k)
+			if not self.toc_children[parent[k]] then
+				table.insert(self.toc_children[0],k)
+			else
+				table.insert(self.toc_children[parent[k]], k)
+			end
 		else --> k and prev must have a common (possibly virtual) ancestor
 			local par = parent[prev]
 			while (self.toc[par].depth > v.depth) do
 				par = parent[par]
 			end
 			parent[k] = parent[par]
-			table.insert(self.toc_children[parent[k]], k)
+			if not self.toc_children[parent[k]] then
+				table.insert(self.toc_children[0],k)
+			else
+				table.insert(self.toc_children[parent[k]], k)
+			end
 		end
 		prev = k
 		prev_depth = self.toc[prev].depth

--- a/util.c
+++ b/util.c
@@ -46,8 +46,9 @@ static int util_df(lua_State *L) {
 	char *path = luaL_checkstring(L, 1);
 	struct statvfs vfs;
 	statvfs(path, &vfs);
+	lua_pushnumber(L, (double)vfs.f_blocks * (double)vfs.f_bsize);
 	lua_pushnumber(L, (double)vfs.f_bfree * (double)vfs.f_bsize);
-	return 1;
+	return 2;
 }
 
 /* Turn UTF-8 char code to Unicode */


### PR DESCRIPTION
1. When executed in the emulator the viewer will crash if you press
   Right on any zip file in the filechooser. This is because the assertion
   on "df /mnt/us | tail -1" will fail as "/mnt/us" is normally
   non-existent.
2. The proper (faster, reliable, portable) way of obtaining the number
   of total and free bytes on a filesystem is by using the statvfs(2)
   system call via util.df Lua interface, see util.c.
3. Removed the "used" field in the function's return as unused and
   unneeded.
