### PR TITLE
Show real time, not cpu time when making screenshots.

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -45,7 +45,14 @@ function CREReader:ZipContentExt(fname)
 		if i > 3 then tmp:close(); break; end
 		i = i + 1
 	end
-	return s and string.lower(string.match(s, ".+%.([^.]+)"))
+	if s then
+		local ext = string.match(s, ".+%.([^.]+)")
+		if ext then
+			ext = string.lower(ext)
+			return ext
+		end
+	end
+	return nil
 end
 
 -- open a CREngine supported file and its settings store

--- a/reader.lua
+++ b/reader.lua
@@ -1,4 +1,4 @@
-#!./kpdfview
+#!./kpdfview.emulator
 --[[
     KindlePDFViewer: a reader implementation
     Copyright (C) 2011 Hans-Werner Hilse <hilse@web.de>
@@ -153,16 +153,11 @@ if ARGV[optind] and lfs.attributes(ARGV[optind], "mode") == "directory" then
 	local running = true
 	FileChooser:setPath(ARGV[optind])
 	while running do
-		local file, callback = FileChooser:choose(0, G_height)
-		if callback then
-			callback()
+		local file = FileChooser:choose(0, G_height)
+		if file then
+			running = openFile(file)
 		else
-			if file ~= nil then
-				running = openFile(file)
-				print(file)
-			else
-				running = false
-			end
+			running = false
 		end
 	end
 elseif ARGV[optind] and lfs.attributes(ARGV[optind], "mode") == "file" then

--- a/reader.lua
+++ b/reader.lua
@@ -1,4 +1,4 @@
-#!./kpdfview.emulator
+#!./kpdfview
 --[[
     KindlePDFViewer: a reader implementation
     Copyright (C) 2011 Hans-Werner Hilse <hilse@web.de>

--- a/screen.lua
+++ b/screen.lua
@@ -18,7 +18,7 @@
 --[[
 Codes for rotation modes:
 
-1 for no rotation, 
+1 for no rotation,
 2 for landscape with bottom on the right side of screen, etc.
 
            2
@@ -26,8 +26,8 @@ Codes for rotation modes:
    | +----------+ |
    | |          | |
    | | Freedom! | |
-   | |          | |  
-   | |          | |  
+   | |          | |
+   | |          | |
  3 | |          | | 1
    | |          | |
    | |          | |
@@ -109,12 +109,15 @@ end
 
 
 function Screen:screenshot()
-	local start = os.clock()
-	--showInfoMsgWithDelay("making screenshot... ", 1000, 1)
-	self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, nil)
+	local secs, usecs = util.gettime()
+	if FileExists("/dev/fb0") then
+		self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, nil)
+	end
+	local nsecs, nusecs = util.gettime()
+	local diff = nsecs - secs + (nusecs - usecs)/1000000
 	--self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, "bzip2 ")
 	--self:fb2pgm("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".pgm", "bzip2 ", 4)
-	showInfoMsgWithDelay(string.format("Screenshot is ready in %.2f(s) ", os.clock()-start), 1000, 1)
+	showInfoMsgWithDelay(string.format("Screenshot is ready in %.2fs ", diff), 2000, 1)
 end
 
 -- NuPogodi (02.07.2012): added the functions to save the fb-content in common graphic files - bmp & pgm.
@@ -122,7 +125,7 @@ end
 
 function Screen:LE(x) -- converts positive upto 32bit-number to a little-endian for bmp-header
 	local s, n = "", 4
-	if x<0x10000 then 
+	if x<0x10000 then
 		s = string.char(0,0)
 		n = 2
 	end
@@ -169,7 +172,7 @@ function Screen:fb2bmp(fin, fout, vflip, pack) -- atm, for 4bpp framebuffers onl
 				outputf:write(content[i])
 			end
 		else -- without v-flip, it takes only 0.02s @ 600x800, 4bpp
-			outputf:write(inputf:read("*all")) 
+			outputf:write(inputf:read("*all"))
 		end
 		inputf:close()
 		outputf:close()
@@ -182,9 +185,10 @@ end
 --[[ This function saves the fb-content (both 4bpp and 8bpp) as 8bpp PGM and pack it.
 It's relatively slow for 4bpp devices such as
 	~2.5s @ K2 and K3 > 600x800, 4bpp
-	~5.0s @ KDX > 824x1200, 
+	~5.0s @ KDX > 824x1200,
 but should be very fast (<<0.1s) when no color conversion (4bpp>8bpp) is needed. ]]
 
+--[[
 function Screen:fb2pgm(fin, fout, pack, bpp)
 	local inputf = assert(io.open(fin,"rb"))
 	if inputf then
@@ -195,7 +199,7 @@ function Screen:fb2pgm(fin, fout, pack, bpp)
 		else	-- convert 4bpp to 8bpp; needs free memory just to store a block = G_width/2 bytes
 			local bpp8, block, i, j, line = {}, G_width/2
 			-- to accelerate a process, let us first create the convertion table: char (0..255) > 2 chars
-			for j=0, 255 do 
+			for j=0, 255 do
 				i = j%16
 				bpp8[#bpp8+1] = string.char(255-j+i, 255-i*16)
 			end
@@ -212,4 +216,4 @@ function Screen:fb2pgm(fin, fout, pack, bpp)
 		if pack then os.execute(pack..fout) end
 	end
 end
-
+]]

--- a/screen.lua
+++ b/screen.lua
@@ -109,10 +109,11 @@ end
 
 
 function Screen:screenshot()
-	local secs, usecs = util.gettime()
-	if FileExists("/dev/fb0") then
-		self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, nil)
+	if util.isEmulated() == 1 then
+		return
 	end
+	local secs, usecs = util.gettime()
+	self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, nil)
 	local nsecs, nusecs = util.gettime()
 	local diff = nsecs - secs + (nusecs - usecs)/1000000
 	--self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, "bzip2 ")

--- a/util.c
+++ b/util.c
@@ -43,7 +43,7 @@ static int util_usleep(lua_State *L) {
 }
 
 static int util_df(lua_State *L) {
-	char *path = luaL_checkstring(L, 1);
+	const char *path = luaL_checkstring(L, 1);
 	struct statvfs vfs;
 	statvfs(path, &vfs);
 	lua_pushnumber(L, (double)vfs.f_blocks * (double)vfs.f_bsize);


### PR DESCRIPTION
@NuPogodi this is your code, so I invite your comments and if you have strong justified objections to this change then this pull request should not be merged. So, here is what I am proposing --- to show the accurate real time spent when making a screenshot instead of the approximate estimate of the CPU usage. The reason is: when making a screenshot the program does not spend all of the time making calculations but also communicating with the eInk controller and eventually writing the dump to the flash device. Therefore, showing a mere "estimate of CPU usage" is misleading, but showing the real time is more useful. What do you think?

Oh, and also I commented out the currently unused function for making screenshots in pgm format.

The other change in this pull request is trivial cleanup (get rid of compile warning and stop crashing screenshots in the emulator).
