### PR TITLE
Various fixes.

### DIFF
--- a/filehistory.lua
+++ b/filehistory.lua
@@ -220,6 +220,7 @@ function FileHistory:addAllCommands()
 		"delete history entry",
 		function(self)
 			file_entry = self.result[self.perpage*(self.page-1)+self.current]
+			if not file_entry then return end
 			local file_to_del = file_entry.dir .. "/" .. file_entry.name
 			os.remove(DocToHistory(file_to_del))
 			-- to avoid showing just deleted file

--- a/unireader.lua
+++ b/unireader.lua
@@ -2261,7 +2261,13 @@ function UniReader:addAllCommands()
 		"go backward in jump history",
 		function(unireader)
 			local prev_jump_no = 0
+			local need_refresh = false
 			if unireader.jump_history.cur > #unireader.jump_history then
+				-- addJump() will cause a "Retrieving TOC..." msg, so we'll
+				-- need to redraw the page after our own
+				-- ifo msg "Already first jump!" below
+				if not self.toc then need_refresh = true end
+
 				-- if cur points to head, put current page in history
 				unireader:addJump(self.pageno)
 				prev_jump_no = unireader.jump_history.cur - 2
@@ -2274,6 +2280,9 @@ function UniReader:addAllCommands()
 				unireader:goto(unireader.jump_history[prev_jump_no].page, true)
 			else
 				showInfoMsgWithDelay("Already first jump!", 2000, 1)
+				if need_refresh then
+					unireader:redrawCurrentPage()
+				end
 			end
 		end)
 	self.commands:add(KEY_BACK,MOD_SHIFT,"Back",


### PR DESCRIPTION
This pull request contains a fix for the crash when trying to delete a non-existent entry in file history.

Also, the fix for the need to redraw page after displaying "Already first jump!" on pressing Back on a freshly opened (i.e. no TOC retrieved yet) file.

Also, just two minor cleanups in the Screen:fb2bmp() function, nothing major:
1. Remove unused assert() around io.open of the input device. The failure
   to open input device is already guarded by the "if inputf" code.
2. Remove unneeded assert() around io.open of the output device. This is
   unneeded because we should not crash the whole application just because
   we cannot write the screen dump (e.g. because filesystem is full, etc) ---
   instead we should exit gracefully.
