### PR TITLE
Jump history in crereader loses the last position.

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -636,12 +636,29 @@ function CREReader:adjustCreReaderCommands()
 	self.commands:add(KEY_BACK, nil, "Back",
 		"go backward in jump history",
 		function(self)
-			local prev_jump_no = self.jump_history.cur - 1
+			local prev_jump_no = 0
+			local need_refresh = false
+			if self.jump_history.cur > #self.jump_history then
+				-- addJump() will cause a "Retrieving TOC..." msg, so we'll
+				-- need to redraw the page after our own
+				-- ifo msg "Already first jump!" below
+				if not self.toc then need_refresh = true end
+
+				-- if cur points to head, put current page in history
+				self:addJump(self.doc:getXPointer())
+				prev_jump_no = self.jump_history.cur - 2
+			else
+				prev_jump_no = self.jump_history.cur - 1
+			end
+
 			if prev_jump_no >= 1 then
 				self.jump_history.cur = prev_jump_no
 				self:goto(self.jump_history[prev_jump_no].page, true, "xpointer")
 			else
 				showInfoMsgWithDelay("Already first jump!", 2000, 1)
+				if need_refresh then
+					self:redrawCurrentPage()
+				end
 			end
 		end
 	)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1297,10 +1297,19 @@ function UniReader:setzoom(page, preCache)
 		self.offset_y = -1 * y0 * self.globalzoom * 2 + margin
 		self.globalzoom = width / (x1 - x0 + margin) * 2
 		Debug("column mode offset:", self.offset_x, self.offset_y, " zoom:", self.globalzoom);
+		self.pan_by_page = self.globalzoom_mode -- store for later and enable pan_by_page
 		self.globalzoom_mode = self.ZOOM_BY_VALUE -- enable pan mode
 		self.pan_x = self.offset_x
 		self.pan_y = self.offset_y
-		self.pan_by_page = true
+	else
+		Debug("globalzoom_mode didn't modify params", self.globalzoom_mode)
+	end
+
+	if self.adjust_offset then
+		Debug("self.ajdust_offset BEFORE ", self.globalzoom, " globalrotate:", self.globalrotate, " offset:", self.offset_x, self.offset_y, " pagesize:", self.fullwidth, self.fullheight, " min_offset:", self.min_offset_x, self.min_offset_y)
+		self.adjust_offset(self)
+		self.adjust_offset = nil
+		Debug("self.ajdust_offset  AFTER ", self.globalzoom, " globalrotate:", self.globalrotate, " offset:", self.offset_x, self.offset_y, " pagesize:", self.fullwidth, self.fullheight, " min_offset:", self.min_offset_x, self.min_offset_y)
 	end
 
 	dc:setZoom(self.globalzoom)
@@ -1542,9 +1551,8 @@ function UniReader:nextView()
 		-- not in fit to content width pan mode, just do a page turn
 		pageno = pageno + 1
 		if self.pan_by_page then
-			-- we are in two column mode
-			self.offset_x = self.pan_x
-			self.offset_y = self.pan_y
+			Debug("two-column pan_by_page", self.pan_by_page)
+			self.globalzoom_mode = self.pan_by_page
 		end
 	end
 
@@ -1570,9 +1578,8 @@ function UniReader:prevView()
 		-- not in fit to content width pan mode, just do a page turn
 		pageno = pageno - 1
 		if self.pan_by_page then
-			-- we are in two column mode
-			self.offset_x = self.pan_x
-			self.offset_y = self.pan_y
+			Debug("two-column pan_by_page", self.pan_by_page)
+			self.globalzoom_mode = self.pan_by_page
 		end
 	end
 
@@ -2743,8 +2750,11 @@ function UniReader:addAllCommands()
 					unireader.offset_x = unireader.offset_x + x
 					if unireader.pan_by_page then
 						if unireader.offset_x > 0 and unireader.pageno > 1 then
-							unireader.offset_x = unireader.pan_x
-							unireader.offset_y = unireader.min_offset_y -- bottom
+							unireader.adjust_offset = function(unireader)
+								unireader.offset_x = unireader.pan_x
+								unireader.offset_y = unireader.min_offset_y
+								Debug("pan to right-bottom of previous page")
+							end
 							unireader:goto(unireader.pageno - 1)
 						else
 							unireader.show_overlap = 0
@@ -2758,8 +2768,8 @@ function UniReader:addAllCommands()
 					unireader.offset_x = unireader.offset_x - x
 					if unireader.pan_by_page then
 						if unireader.offset_x < unireader.min_offset_x - unireader.pan_margin and unireader.pageno < unireader.doc:getPages() then
-							unireader.offset_x = unireader.pan_x
-							unireader.offset_y = unireader.pan_y
+							Debug("pan to top-left of next page")
+							self.globalzoom_mode = self.pan_by_page
 							unireader:goto(unireader.pageno + 1)
 						else
 							unireader.show_overlap = 0


### PR DESCRIPTION
This is a fix for the issue #331.

Note that although the pull request seems to contain four commits this is merely because I accidentally merged @dpavlin 's twocolumn fixes in my local master branch. However, the actual changes contained in this pull request only affect crereader.lua i.e. have nothing to do with @dpavlin 's changes. Next time I will be more careful when switching between local and remote branches...
