### PR TITLE
Fix from NuPogodi: initialize scfont face properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,15 @@
 lua
 lua-*
 .reader.kpdfview.lua
+settings.reader.lua
 mupdf-thirdparty.zip
 djvulibre*
+cr3cache
+history
+crash.log
+.vimrc
+data
+fonts
 kpdfview
 *.o
 

--- a/selectmenu.lua
+++ b/selectmenu.lua
@@ -12,7 +12,6 @@ SelectMenu = {
 	-- font for paging display
 	ffsize = 16,
 	-- font for item shortcut
-	sface = Font:getFace("scfont", 22),
 
 	-- title height
 	title_H = 40,
@@ -287,6 +286,7 @@ function SelectMenu:choose(ypos, height)
 		local cface = Font:getFace("cfont", 22)
 		local tface = Font:getFace("tfont", 25)
 		local fface = Font:getFace("ffont", 16)
+		local sface = Font:getFace("scfont", 22)
 		
 		local lx = self.margin_H + 40
 		local fw = fb.bb:getWidth() - lx - self.margin_H
@@ -326,7 +326,7 @@ function SelectMenu:choose(ypos, height)
 							renderUtf8Text(fb.bb, self.margin_H + 3, y, fface,
 								self.item_shortcuts[c], true)
 						else
-							renderUtf8Text(fb.bb, self.margin_H + 8, y, self.sface,
+							renderUtf8Text(fb.bb, self.margin_H + 8, y, sface,
 								self.item_shortcuts[c], true)
 						end
 


### PR DESCRIPTION
This fixes the bug of non-persistency of user's setting of scfont.

The fix taken from several commits by @NuPogodi into his master branch. The reason I had to pick this fix manually is to assist @NuPogodi as he wouldn't be able to do a pull request until the major item (his implementation of new InfoMessage:inform() interface) is merged but the fix cannot wait until then because it is needed in the current stable "just about to be released" tree. You don't need to thank me, @NuPogodi --- you are welcome :)
