### PR TITLE
Typo: --disable-largefiles -> --disable-largefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,9 @@ $(MUPDFLIBS) $(THIRDPARTYLIBS): $(MUPDFDIR)/cmapdump.host $(MUPDFDIR)/fontdump.h
 $(DJVULIBS):
 	-mkdir $(DJVUDIR)/build
 ifdef EMULATE_READER
-	cd $(DJVUDIR)/build && ../configure --disable-desktopfiles --disable-shared --enable-static --disable-xmltools --disable-largefiles
+	cd $(DJVUDIR)/build && ../configure --disable-desktopfiles --disable-shared --enable-static --disable-xmltools --disable-largefile
 else
-	cd $(DJVUDIR)/build && ../configure --disable-desktopfiles --disable-shared --enable-static --host=$(HOST) --disable-xmltools --disable-largefiles
+	cd $(DJVUDIR)/build && ../configure --disable-desktopfiles --disable-shared --enable-static --host=$(HOST) --disable-xmltools --disable-largefile
 endif
 	make -C $(DJVUDIR)/build
 

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ djvu.o: %.o: %.c
 	$(CC) -c $(KPDFREADER_CFLAGS) -I$(DJVUDIR)/ $< -o $@
 
 cre.o: %.o: %.cpp
-	$(CC) -c -I$(CRENGINEDIR)/crengine/include/ -I$(LUADIR)/src $< -o $@ -lstdc++
+	$(CC) -c $(CFLAGS) -I$(CRENGINEDIR)/crengine/include/ -I$(LUADIR)/src $< -o $@
 
 lfs.o: $(LFSDIR)/src/lfs.c
 	$(CC) -c $(CFLAGS) -I$(LUADIR)/src -I$(LFSDIR)/src $(LFSDIR)/src/lfs.c -o $@

--- a/launchpad/kpdf.sh
+++ b/launchpad/kpdf.sh
@@ -22,7 +22,7 @@ fi
 killall -stop cvm
 
 # finally call reader
-./reader.lua -d "$1" 2> /mnt/us/kindlepdfviewer/crash.log || cat /mnt/us/kindlepdfviewer/crash.log
+./reader.lua "$1" 2> /mnt/us/kindlepdfviewer/crash.log || cat /mnt/us/kindlepdfviewer/crash.log
 
 # unmount system fonts
 if grep /mnt/us/kindlepdfviewer/fonts/host /proc/mounts; then

--- a/pdf.c
+++ b/pdf.c
@@ -623,7 +623,7 @@ static int getPageLinks(lua_State *L) {
 		lua_rawseti(L, -2, ++link_count);
     }
 
-	printf("## getPageLinks found %d links in document\n", link_count);
+	//printf("## getPageLinks found %d links in document\n", link_count);
 
 	fz_drop_link(page->doc->context, page_links);
 


### PR DESCRIPTION
As a result of a simple typo we were continuing to include LFS
support in djvulibre unnecessarily...
