### PR TITLE
Two fixes from NuPogodi

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -90,8 +90,9 @@ end
 
 function DrawFooter(text,font_face,h)
 	local y = G_height - 7
-	local x = (G_width / 2) - 50
-	renderUtf8Text(fb.bb, x, y, font_face, text, true)
+	-- NuPogodi, 29.09.12: just dirty fix to have the same footer everywhere
+	local x = FileChooser.margin_H --(G_width / 2) - 50
+	renderUtf8Text(fb.bb, x, y, font_face, text.."  - Press H for help", true)
 end
 
 function DrawFileItem(name,x,y,image)

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -200,6 +200,8 @@ function FileInfo:show(path, name)
 				dy = dy + renderUtf8Multiline(fb.bb, xrcol, y, cface, self.result[c].name, true,
 						G_width - self.margin_H - xrcol, 1.65).y - y
 			end
+			-- NuPogodi, 29.09.12: restored footer > to see 'Press H for help'
+			DrawFooter("Page 1 of 1",fface,self.foot_H)
 			fb:refresh(0)
 			self.pagedirty = false
 		end

--- a/inputbox.lua
+++ b/inputbox.lua
@@ -493,7 +493,7 @@ function InputBox:defineCalcFunctions() -- for the calculator documentation
 	self.calcfunctions:del(KEY_OUTOF_SCREEN_SAVER, nil, "Slider")
 	self.calcfunctions:del(KEY_CHARGING, nil, "plugin/out usb")
 	self.calcfunctions:del(KEY_NOT_CHARGING, nil, "plugin/out usb")
-	self.calcfunctions:del(KEY_SPACE, MOD_ALT, "Space")
+	self.calcfunctions:del(KEY_P, MOD_SHIFT, "P")
 
 	local s = " " -- space for function groups
 	local a = 100 -- arithmetic functions


### PR DESCRIPTION
1. ATM, the footers in selectmenu.lua & helppage.lua are left-adjusted,
   these also contain the prompt for users how to call help
   (selectmenu.lua) and how to go back (helppage.lua). By minor correction
   to function DrawFooter() in filechooser.lua, one may readily make the
   rest footers to look in a similar way.
2. When writing the code of inputbox.lua, I (NuPogodi) left the wrong
   command to delete the 1st entry in the math function list
   (called in calculator mode by pressing Alt-M).

(committing on behalf of NuPogodi because it may be tricky for him to do a pull request at the moment as the master tree has other changes).
