### PR TITLE
Restrict the values of rcountmax to the range 0 to 10.

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -2487,10 +2487,13 @@ function UniReader:addAllCommands()
 			local count = NumInputBox:input(G_height-100, 100,
 				"Full refresh after:", self.rcountmax, true)
 			-- convert string to number
-			if pcall(function () count = count + 0 end) then
-				-- restrict self.rcountmax in reasonable range
-				self.rcountmax = math.max(count, 0)
-				self.rcountmax = math.min(self.rcountmax, 10)
+			if pcall(function () count = math.floor(count) end) then
+				if count < 0 then
+					count = 0
+				elseif count > 10 then
+					count = 10
+				end
+				self.rcountmax = count
 				-- storing this parameter in both global and local settings
 				G_reader_settings:saveSetting("rcountmax", self.rcountmax)
 				self.settings:saveSetting("rcountmax", self.rcountmax)

--- a/unireader.lua
+++ b/unireader.lua
@@ -2490,7 +2490,7 @@ function UniReader:addAllCommands()
 			if pcall(function () count = count + 0 end) then
 				-- restrict self.rcountmax in reasonable range
 				self.rcountmax = math.max(count, 0)
-				self.rcountmax = math.min(count, 10)
+				self.rcountmax = math.min(self.rcountmax, 10)
 				-- storing this parameter in both global and local settings
 				G_reader_settings:saveSetting("rcountmax", self.rcountmax)
 				self.settings:saveSetting("rcountmax", self.rcountmax)


### PR DESCRIPTION
Currently the user can press `Shift-R` and enter a value like -10 which is accepted and saved in the settings files. Not anymore.

(Oh, and forgive the "Merge remote-tracking branch" entries in the commit list. I do remember the --rebase advice, but I always follow good advices as soon as I understand them, i.e. I have not yet understood the meaning of --rebase switch :)
