### PR TITLE
Build optimizations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ HOSTCXX:=g++
 CFLAGS:=-O3 $(SYSROOT)
 CXXFLAGS:=-O3 $(SYSROOT)
 LDFLAGS:= $(SYSROOT)
-ARM_CFLAGS:=-march=armv6
+ARM_CFLAGS:=-march=armv6j -mtune=arm1136jf-s -mfpu=vfp
 # use this for debugging:
 #CFLAGS:=-O0 -g
 
@@ -58,6 +58,7 @@ ifdef EMULATE_READER
 	endif
 else
 	CFLAGS+= $(ARM_CFLAGS)
+	CXXFLAGS+= $(ARM_CFLAGS)
 endif
 
 # standard includes
@@ -193,7 +194,7 @@ endif
 
 $(CRENGINELIBS):
 	cd $(KPVCRLIBDIR) && rm -rf CMakeCache.txt CMakeFiles && \
-		CFLAGS="$(CFLAGS)" CC="$(CC)" CXX="$(CXX)" cmake . && \
+		CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CC="$(CC)" CXX="$(CXX)" cmake . && \
 		make
 
 $(LUALIB):

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ HOSTCXX:=g++
 
 CFLAGS:=-O3 $(SYSROOT)
 CXXFLAGS:=-O3 $(SYSROOT)
-LDFLAGS:= $(SYSROOT)
+LDFLAGS:=-Wl,-O1 -Wl,--as-needed
 ARM_CFLAGS:=-march=armv6j -mtune=arm1136jf-s -mfpu=vfp
 # use this for debugging:
 #CFLAGS:=-O0 -g
@@ -92,6 +92,7 @@ all:kpdfview
 
 kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o util.o ft.o lfs.o mupdfimg.o $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) djvu.o $(DJVULIBS) cre.o $(CRENGINELIBS)
 	$(CC) \
+		$(CFLAGS) \
 		kpdfview.o \
 		einkfb.o \
 		pdf.o \
@@ -110,6 +111,7 @@ kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o util.o ft
 		cre.o \
 		$(CRENGINELIBS) \
 		$(STATICLIBSTDCPP) \
+		$(LDFLAGS) \
 		-o kpdfview -lm -ldl -lpthread $(EMU_LDFLAGS) $(DYNAMICLIBSTDCPP)
 
 slider_watcher: slider_watcher.c
@@ -194,7 +196,7 @@ endif
 
 $(CRENGINELIBS):
 	cd $(KPVCRLIBDIR) && rm -rf CMakeCache.txt CMakeFiles && \
-		CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CC="$(CC)" CXX="$(CXX)" cmake . && \
+		CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" CC="$(CC)" CXX="$(CXX)" LDFLAGS="$(LDFLAGS)" cmake . && \
 		make
 
 $(LUALIB):

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 LUADIR=luajit-2.0
 MUPDFDIR=mupdf
-MUPDFTARGET=build/debug
+MUPDFTARGET=build/release
 MUPDFLIBDIR=$(MUPDFDIR)/$(MUPDFTARGET)
 DJVUDIR=djvulibre
 KPVCRLIBDIR=kpvcrlib
@@ -158,7 +158,7 @@ clean:
 
 cleanthirdparty:
 	-make -C $(LUADIR) clean
-	-make -C $(MUPDFDIR) clean
+	-make -C $(MUPDFDIR) build="release" clean
 	-make -C $(CRENGINEDIR)/thirdparty/antiword clean
 	test -d $(CRENGINEDIR)/thirdparty/chmlib && make -C $(CRENGINEDIR)/thirdparty/chmlib clean || echo warn: chmlib folder not found
 	test -d $(CRENGINEDIR)/thirdparty/libpng && (make -C $(CRENGINEDIR)/thirdparty/libpng clean) || echo warn: chmlib folder not found
@@ -169,18 +169,18 @@ cleanthirdparty:
 	-rm -f $(MUPDFDIR)/cmapdump.host
 
 $(MUPDFDIR)/fontdump.host:
-	make -C mupdf CC="$(HOSTCC)" $(MUPDFTARGET)/fontdump
+	make -C mupdf build="release" CC="$(HOSTCC)" $(MUPDFTARGET)/fontdump
 	cp -a $(MUPDFLIBDIR)/fontdump $(MUPDFDIR)/fontdump.host
 	make -C mupdf clean
 
 $(MUPDFDIR)/cmapdump.host:
-	make -C mupdf CC="$(HOSTCC)" $(MUPDFTARGET)/cmapdump
+	make -C mupdf build="release" CC="$(HOSTCC)" $(MUPDFTARGET)/cmapdump
 	cp -a $(MUPDFLIBDIR)/cmapdump $(MUPDFDIR)/cmapdump.host
 	make -C mupdf clean
 
 $(MUPDFLIBS) $(THIRDPARTYLIBS): $(MUPDFDIR)/cmapdump.host $(MUPDFDIR)/fontdump.host
 	# build only thirdparty libs, libfitz and pdf utils, which will care for libmupdf.a being built
-	CFLAGS="$(CFLAGS) -DNOBUILTINFONT" make -C mupdf CC="$(CC)" CMAPDUMP=cmapdump.host FONTDUMP=fontdump.host MUPDF= MU_APPS= BUSY_APP= XPS_APPS= verbose=1
+	CFLAGS="$(CFLAGS) -DNOBUILTINFONT" make -C mupdf build="release" CC="$(CC)" CMAPDUMP=cmapdump.host FONTDUMP=fontdump.host MUPDF= MU_APPS= BUSY_APP= XPS_APPS= verbose=1
 
 $(DJVULIBS):
 	-mkdir $(DJVUDIR)/build

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ all:kpdfview
 
 kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o util.o ft.o lfs.o mupdfimg.o $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) djvu.o $(DJVULIBS) cre.o $(CRENGINELIBS)
 	$(CC) \
-		$(CFLAGS) \
 		kpdfview.o \
 		einkfb.o \
 		pdf.o \
@@ -111,7 +110,6 @@ kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o util.o ft
 		cre.o \
 		$(CRENGINELIBS) \
 		$(STATICLIBSTDCPP) \
-		$(LDFLAGS) \
 		-o kpdfview -lm -ldl -lpthread $(EMU_LDFLAGS) $(DYNAMICLIBSTDCPP)
 
 slider_watcher: slider_watcher.c


### PR DESCRIPTION
1. Thanks to NiLuJe who pointed out that we are building mupdf in debug
   mode. Switching to "release" build reduced the size of the kpdfview
   binary and did not cause any performance degradation (but no noticeable
   improvement either --- the page handling times seem to be exactly the
   same, i.e. fluctuating a couple of ms in both directions).
2. Enabled ARM-specific optimization -march=armv6j -mtune=arm1136jf-s -mfpu=vfp (also in CXXFLAGS for crengine) as per @NiLuJe 's recommendation.
3. Enabled LTO for kpdfview and crengine as per @NiLuJe 's recommendation.
