### PR TITLE
show reneding page_indicator only in debug mode

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -100,6 +100,7 @@ function Debug(...)
 		end
 	end
 	print("#"..line)
+	return true -- debug enabled
 end
 
 -- simple serialization function, won't do uservalues, functions, loops

--- a/unireader.lua
+++ b/unireader.lua
@@ -1048,10 +1048,11 @@ function UniReader:drawOrCache(no, preCache)
 	-- #4 goal: we render next page, too. (TODO)
 
 	local pg_w = G_width / ( self.doc:getPages() )
-	local page_indicator = function() 
-		fb.bb:invertRect( pg_w*(no-1),0, pg_w,10)
-		fb:refresh(1,     pg_w*(no-1),0, pg_w,10)
-		Debug('page_indicator',no)
+	local page_indicator = function()
+		if Debug('page_indicator',no) then
+			fb.bb:invertRect( pg_w*(no-1),0, pg_w,10)
+			fb:refresh(1,     pg_w*(no-1),0, pg_w,10)
+		end
 	end
 	page_indicator()
 


### PR DESCRIPTION
This addresses performance degradation because of two e-ink refreshes
introduced by this feature #349
