### PR TITLE
Various cleanups.

### DIFF
--- a/dialog.lua
+++ b/dialog.lua
@@ -215,6 +215,9 @@ function InfoMessage:incrTTSspeed(direction) -- either +1 or -1
 end
 
 function InfoMessage:getTTSspeed()
+	if util.isEmulated() == 1 then
+		return 0
+	end
 	local tmp = io.popen('lipc-get-prop com.lab126.tts TtsISpeed', "r")
 	local speed = tmp:read("*number")
 	tmp:close()
@@ -234,6 +237,9 @@ function InfoMessage:incrSoundVolume(direction) -- either +1 or -1
 end
 
 function InfoMessage:getSoundVolume()
+	if util.isEmulated() == 1 then
+		return 0
+	end
 	local tmp = io.popen('lipc-get-prop com.lab126.audio Volume', "r")
 	local volume = tmp:read("*number")
 	tmp:close()

--- a/unireader.lua
+++ b/unireader.lua
@@ -1512,7 +1512,8 @@ end
 
 -- change current page and cache next page after rendering
 function UniReader:goto(no, is_ignore_jump)
-	if no < 1 or no > self.doc:getPages() then
+	local numpages = self.doc:getPages()
+	if no < 1 or no > numpages then
 		return
 	end
 
@@ -1529,9 +1530,11 @@ function UniReader:goto(no, is_ignore_jump)
 
 	-- TODO: move the following to a more appropriate place
 	-- into the caching section
-	if no < self.doc:getPages() then
+	if no < numpages then
 		if #self.bbox == 0 or not self.bbox.enabled then
 			-- pre-cache next page, but if we will modify bbox don't!
+			-- Tigran: I think we should _always_ precache the page
+			-- because of the benefits of pre-decoding it (for DjVu).
 			self:drawOrCache(no+1, true)
 		end
 	end


### PR DESCRIPTION
I'll put into this pull request various cleanups, so please don't merge until I am finished:
1. When running on the emulator don't attempt to perform any of the TTS
   functions as this will crash the application. Note that the crashes will occur when merely pressing "I" or just exiting the program and NOT if the user attempts to do any of TTS (otherwise it would not be a bug as one would just say "don't do that in emulator") --- but one may need to change message settings AND definitely needs to exit application in the emulator too :)
2. In UniReader:goto() no need to call self.doc:getPages() twice, just save the value in the local variable.
