### PR TITLE
Small fixes to "Last Documents" dialog and crengine font initialization.

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -24,9 +24,11 @@ function CREReader:init()
 	-- we need to initialize the CRE font list
 	local fonts = Font:getFontList()
 	for _k, _v in ipairs(fonts) do
-		local ok, err = pcall(cre.registerFont, Font.fontdir..'/'.._v)
-		if not ok then
-			Debug(err)
+		if _v ~= "Dingbats.cff" and _v ~= "StandardSymL.cff" then
+			local ok, err = pcall(cre.registerFont, Font.fontdir..'/'.._v)
+			if not ok then
+				Debug(err)
+			end
 		end
 	end
 


### PR DESCRIPTION
1. Remove ".." entry as unnecessary waste of (rather limited) space.
   Pressing KEY_BACK returns the user from this dialog, so there is no need
   for the ".." entry.
2. Simplify FileHistory:init() function as it does not really need the
   argument --- our history location is fixed and hardcoded.
3. Remove KEY_HOME quit key from history command handlers. Pressing Home
   key too many times would cause the application to exit, which is
   very annoying.
4. Show the number of items in the header next to "Last Documents".
5. Don't try to register the two fonts Dingbats and StandardSymL with crengine to speed up startup.
