### PR TITLE
Kill getDiskSizeInfo() function and make only Back (not Home) return from Search.

### DIFF
--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -57,17 +57,9 @@ function getUnpackedZipSize(zipfile)
 	return tonumber(res)
 end
 
-function getDiskSizeInfo()
-	local t, f = util.df(".")
-	return { total = t, free = f }
-end
-
 function FileInfo:formatDiskSizeInfo()
-	local s = getDiskSizeInfo()
-	if s then
-		return self:FormatSize(s.free)..string.format(", %.2f", 100*s.free/s.total).."%"
-	end
-	return "?"
+	local t, f = util.df(".")
+	return self:FormatSize(f)..string.format(", %.2f", 100*f/t).."%"
 end
 
 function FileInfo:getFolderContent()

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -76,11 +76,7 @@ function FileSearcher:setSearchResult(keywords)
 end
 
 function FileSearcher:init(search_path)
-	if search_path then
-		self:setPath(search_path)
-	else
-		self:setPath("/mnt/us/documents")
-	end
+	self:setPath(search_path or "/mnt/us/documents")
 	self:addAllCommands()
 end
 
@@ -245,7 +241,7 @@ function FileSearcher:addAllCommands()
 			self.pagedirty = true
 		end
 	)
-	self.commands:add({KEY_BACK, KEY_HOME}, nil, "Back",
+	self.commands:add(KEY_BACK, nil, "Back",
 		"back",
 		function(self)
 			return "break"


### PR DESCRIPTION
1. Instead of making an extra function call, packing return values in key'd
   values of a table and then use two table indexing operations, just call
   util.df(".") directly from FileInfo:formatDiskSizeInfo() and use its two
   return values appropriately.
2. Make only Back (not Home) return from Search results. For more info see the commit message.
