### PR TITLE
Kill "Retrieving TOC..." message and simplify code.

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -639,13 +639,7 @@ function CREReader:adjustCreReaderCommands()
 		"go backward in jump history",
 		function(self)
 			local prev_jump_no = 0
-			local need_refresh = false
 			if self.jump_history.cur > #self.jump_history then
-				-- addJump() will cause a "Retrieving TOC..." msg, so we'll
-				-- need to redraw the page after our own
-				-- ifo msg "Already first jump!" below
-				if not self.toc then need_refresh = true end
-
 				-- if cur points to head, put current page in history
 				self:addJump(self.doc:getXPointer())
 				prev_jump_no = self.jump_history.cur - 2
@@ -658,9 +652,6 @@ function CREReader:adjustCreReaderCommands()
 				self:goto(self.jump_history[prev_jump_no].page, true, "xpointer")
 			else
 				showInfoMsgWithDelay("Already first jump!", 2000, 1)
-				if need_refresh then
-					self:redrawCurrentPage()
-				end
 			end
 		end
 	)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1647,7 +1647,6 @@ function UniReader:cleanUpTocTitle(title)
 end
 
 function UniReader:fillToc()
-	InfoMessage:show("Retrieving TOC...", 1)
 	self.toc = self.doc:getToc()
 	self.toc_children = {}
 	self.toc_xview = {}
@@ -2147,7 +2146,7 @@ function UniReader:showMenu()
 	self:_drawReadingInfo()
 
 	fb:refresh(1)
-	while 1 do
+	while true do
 		local ev = input.saveWaitForEvent()
 		ev.code = adjustKeyEvents(ev)
 		if ev.type == EV_KEY and ev.value == EVENT_VALUE_KEY_PRESS then
@@ -2286,13 +2285,7 @@ function UniReader:addAllCommands()
 		"go backward in jump history",
 		function(unireader)
 			local prev_jump_no = 0
-			local need_refresh = false
 			if unireader.jump_history.cur > #unireader.jump_history then
-				-- addJump() will cause a "Retrieving TOC..." msg, so we'll
-				-- need to redraw the page after our own
-				-- ifo msg "Already first jump!" below
-				if not unireader.toc then need_refresh = true end
-
 				-- if cur points to head, put current page in history
 				unireader:addJump(self.pageno)
 				prev_jump_no = unireader.jump_history.cur - 2
@@ -2305,9 +2298,6 @@ function UniReader:addAllCommands()
 				unireader:goto(unireader.jump_history[prev_jump_no].page, true)
 			else
 				showInfoMsgWithDelay("Already first jump!", 2000, 1)
-				if need_refresh then
-					unireader:redrawCurrentPage()
-				end
 			end
 		end)
 	self.commands:add(KEY_BACK,MOD_SHIFT,"Back",


### PR DESCRIPTION
After some consideration I believe that it is best to get rid of
"Retrieving TOC..." message altogether on the following grounds:
1. The code in unireader.lua/crereader.lua that has to deal with this
   specifically can be removed.
2. The fillToc() is a data manipulation function and ought not to touch
   graphical state.
3. The files for which retrieving TOC can take a long time are
   _exceptionally_ rare (only two are known to me --- both are my own
   editions with detailed morphological tags which require massive
   hierarchical TOC for quick navigation)
4. Users are going to be confused when they press Menu for the first
   time and see "Retrieving TOC..." staying on the screen until they press
   Menu again.

This fixes issue #367 --- thanks to @dracodoc for pointing this out.
