### PR TITLE
Small typo that wasted millions of instructions...

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -554,7 +554,7 @@ int luaopen_cre(lua_State *L) {
 	/* initialize font manager for CREngine */
 	InitFontManager(lString8());
 
-#ifdef DEBUG_CRENGINE
+#if DEBUG_CRENGINE
 	CRLog::setStdoutLogger();
 	CRLog::setLogLevel(CRLog::LL_DEBUG);
 #endif

--- a/unireader.lua
+++ b/unireader.lua
@@ -2665,7 +2665,7 @@ function UniReader:addAllCommands()
 							elseif y_direction == -1 then
 								max = y_s
 							else
-								print("ERROR: unknown direction!")
+								Debug("ERROR: unknown direction!")
 							end
 
 							max = max / step


### PR DESCRIPTION
Now that `#define CRENGINE_DEBUG` is handled correctly, all those pesky
messages from crengine are gone and so the performance of crereader
should be better --- remember that under some circumstances
crengine generates literally THOUSANDS of debug messages per second
(e.g. when complaining about corrupt TOC nodes and there are _plenty_ of
fb2 files out there which have an invalid structure).
