### PR TITLE
Prevent crash when opening a stale history entry

### DIFF
--- a/filehistory.lua
+++ b/filehistory.lua
@@ -227,13 +227,17 @@ function FileHistory:addAllCommands()
 		function(self)
 			local file_entry = self.result[self.perpage*(self.page-1)+self.current]
 			file_full_path = file_entry.dir .. "/" .. file_entry.name
-			openFile(file_full_path)
-			--reset height and item index if screen has been rotated
-			local item_no = self.perpage * (self.page - 1) + self.current
-			self.perpage = math.floor(G_height / self.spacing) - 2
-			self.current = item_no % self.perpage
-			self.page = math.floor(item_no / self.perpage) + 1
-			self.pagedirty = true
+			if FileExists(file_full_path) then
+				openFile(file_full_path)
+				--reset height and item index if screen has been rotated
+				local item_no = self.perpage * (self.page - 1) + self.current
+				self.perpage = math.floor(G_height / self.spacing) - 2
+				self.current = item_no % self.perpage
+				self.page = math.floor(item_no / self.perpage) + 1
+				self.pagedirty = true
+			else
+				InfoMessage:inform("File does not exist", 2000, 1, MSG_ERROR, "File does not exist")
+			end
 		end
 	)
 	self.commands:add(KEY_DEL, nil, "Del",

--- a/filehistory.lua
+++ b/filehistory.lua
@@ -236,7 +236,7 @@ function FileHistory:addAllCommands()
 				self.page = math.floor(item_no / self.perpage) + 1
 				self.pagedirty = true
 			else
-				InfoMessage:inform("File does not exist", 2000, 1, MSG_ERROR, "File does not exist")
+				InfoMessage:inform("File does not exist ", 2000, 1, MSG_ERROR)
 			end
 		end
 	)


### PR DESCRIPTION
This fixes the issue #370 raised by dracodoc.
When the user removes or renames the book which was previously opened
and tries to open it again via (now stale) history entry we are passing
the filename of a non-existent file to the format-specific
:openDocument() method and the behaviour depends on the format. For PDF
and DjVu files it is okay --- they just return an error, but for _some_
crengine files (e.g. ePub, but not fb2.zip) we get a coredump.
Anyway, the proper solution is to not attempt to open a non-existent
file but give a more meaningful message (than, for example:
"ddjvu: **Unrecognized DjVu Me" for DjVu case) which informs the user
that the history entry is stale. If he has valuable data in it (such as
highlights, etc) he can save them, otherwise he can delete the history
entry there and then.
