### PR TITLE
Display DjVu info in the status line.

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -199,11 +199,10 @@ static int openPage(lua_State *L) {
 
 	/* djvulibre counts page starts from 0 */
 	page->page_ref = ddjvu_page_create_by_pageno(doc->doc_ref, pageno - 1);
+	if (! page->page_ref)
+		return luaL_error(L, "cannot open page #%d", pageno);
 	while (! ddjvu_page_decoding_done(page->page_ref))
 		handle(L, doc->context, TRUE);
-	if (! page->page_ref) {
-		return luaL_error(L, "cannot open page #%d", pageno);
-	}
 
 	page->doc = doc;
 	page->num = pageno;
@@ -255,8 +254,20 @@ static int getOriginalPageSize(lua_State *L) {
 
 	lua_pushnumber(L, info.width);
 	lua_pushnumber(L, info.height);
+	lua_pushnumber(L, info.dpi);
 
-	return 2;
+	return 3;
+}
+
+static int getPageInfo(lua_State *L) {
+	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
+	int pageno = luaL_checkint(L, 2);
+	ddjvu_page_t *djvu_page;
+	djvu_page = ddjvu_page_create_by_pageno(doc->doc_ref, pageno - 1);
+	if (!djvu_page)
+		return luaL_error(L, "cannot create djvu_page #%d", pageno);
+	while (! ddjvu_page_decoding_done(djvu_page))
+		handle(L, doc->context, TRUE);
 }
 
 /*
@@ -527,6 +538,7 @@ static const struct luaL_Reg djvudocument_meth[] = {
 	{"getToc", getTableOfContent},
 	{"getPageText", getPageText},
 	{"getOriginalPageSize", getOriginalPageSize},
+	{"getPageInfo", getPageInfo},
 	{"close", closeDocument},
 	{"getCacheSize", getCacheSize},
 	{"cleanCache", cleanCache},

--- a/djvu.c
+++ b/djvu.c
@@ -85,11 +85,10 @@ static int openDocument(lua_State *L) {
 	ddjvu_cache_set_size(doc->context, (unsigned long)cache_size);
 
 	doc->doc_ref = ddjvu_document_create_by_filename_utf8(doc->context, filename, TRUE);
+	if (! doc->doc_ref)
+		return luaL_error(L, "cannot open DjVu file <%s>", filename);
 	while (! ddjvu_document_decoding_done(doc->doc_ref))
 		handle(L, doc->context, True);
-	if (! doc->doc_ref) {
-		return luaL_error(L, "cannot open DjVu file <%s>", filename);
-	}
 
 	doc->pixelformat = ddjvu_format_create(DDJVU_FORMAT_GREY8, 0, NULL);
 	if (! doc->pixelformat) {
@@ -254,20 +253,65 @@ static int getOriginalPageSize(lua_State *L) {
 
 	lua_pushnumber(L, info.width);
 	lua_pushnumber(L, info.height);
-	lua_pushnumber(L, info.dpi);
 
-	return 3;
+	return 2;
 }
 
 static int getPageInfo(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
 	int pageno = luaL_checkint(L, 2);
 	ddjvu_page_t *djvu_page;
+	int page_width, page_height, page_dpi;
+	double page_gamma;
+	ddjvu_page_type_t page_type;
+	char *page_type_str;
+
 	djvu_page = ddjvu_page_create_by_pageno(doc->doc_ref, pageno - 1);
-	if (!djvu_page)
+	if (! djvu_page)
 		return luaL_error(L, "cannot create djvu_page #%d", pageno);
+
 	while (! ddjvu_page_decoding_done(djvu_page))
 		handle(L, doc->context, TRUE);
+
+	page_width = ddjvu_page_get_width(djvu_page);
+	lua_pushnumber(L, page_width);
+
+	page_height = ddjvu_page_get_height(djvu_page);
+	lua_pushnumber(L, page_height);
+
+	page_dpi = ddjvu_page_get_resolution(djvu_page);
+	lua_pushnumber(L, page_dpi);
+
+	page_gamma = ddjvu_page_get_gamma(djvu_page);
+	lua_pushnumber(L, page_gamma);
+
+	page_type = ddjvu_page_get_type(djvu_page);
+	switch (page_type) {
+		case DDJVU_PAGETYPE_UNKNOWN:
+			page_type_str = "UNKNOWN";
+			break;
+
+		case DDJVU_PAGETYPE_BITONAL:
+			page_type_str = "BITONAL";
+			break;
+
+		case DDJVU_PAGETYPE_PHOTO:
+			page_type_str = "PHOTO";
+			break;
+
+		case DDJVU_PAGETYPE_COMPOUND:
+			page_type_str = "COMPOUND";
+			break;
+
+		default:
+			page_type_str = "INVALID";
+			break;
+	}
+	lua_pushstring(L, page_type_str);
+
+	ddjvu_page_release(djvu_page);
+
+	return 5;
 }
 
 /*

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -70,19 +70,14 @@ function DJVUReader:invertTextYAxel(pageno, text_table)
 	return text_table
 end
 
--- used in UniReader:showMenu()
----[[
 function DJVUReader:_drawReadingInfo()
-	local secs, usecs = util.gettime()
 	local width, height = G_width, G_height
 	local numpages = self.doc:getPages()
 	local load_percent = self.pageno/numpages
-	-- changed to be the same font group as originaly intended
 	local face = Font:getFace("rifont", 20)
-	--local page_width, page_height, page_dpi = self.doc:getOriginalPageSize(self.pageno)
-	local page_width, page_height, page_dpi = self.doc:getPageInfo(self.pageno)
+	local page_width, page_height, page_dpi, page_gamma, page_type = self.doc:getPageInfo(self.pageno)
 
-	-- display memory on top of page
+	-- display memory, time, battery and DjVu info on top of page
 	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
@@ -91,9 +86,9 @@ function DJVUReader:_drawReadingInfo()
 		os.date("%a %d %b %Y %T")..
 		" ["..BatteryLevel().."]", true)
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,
-		"Gamma:"..tostring(self.globalgamma)..", "..
+		"Gm:"..string.format("%.1f",self.globalgamma).." ["..tostring(page_gamma).."], "..
 		tostring(page_width).."x"..tostring(page_height)..", "..
-		tostring(page_dpi).."dpi", true)
+		tostring(page_dpi).."dpi, "..page_type, true)
 
 	-- display reading progress on bottom of page
 	local ypos = height - 50
@@ -109,8 +104,4 @@ function DJVUReader:_drawReadingInfo()
 	ypos = ypos + 15
 	blitbuffer.progressBar(fb.bb, 10, ypos, width-20, 15,
 							5, 4, load_percent, 8)
-	local nsecs, nusecs = util.gettime()
-	local diff = (nsecs - secs)*1000000 + nusecs - usecs
-	print("DJVUReader:_drawReadingInfo(): "..tostring(diff).." us")
 end
---]]

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -69,3 +69,48 @@ function DJVUReader:invertTextYAxel(pageno, text_table)
 	end
 	return text_table
 end
+
+-- used in UniReader:showMenu()
+---[[
+function DJVUReader:_drawReadingInfo()
+	local secs, usecs = util.gettime()
+	local width, height = G_width, G_height
+	local numpages = self.doc:getPages()
+	local load_percent = self.pageno/numpages
+	-- changed to be the same font group as originaly intended
+	local face = Font:getFace("rifont", 20)
+	--local page_width, page_height, page_dpi = self.doc:getOriginalPageSize(self.pageno)
+	local page_width, page_height, page_dpi = self.doc:getPageInfo(self.pageno)
+
+	-- display memory on top of page
+	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
+	renderUtf8Text(fb.bb, 10, 15+6, face,
+		"M: "..
+		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k, "..
+		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k, "..
+		os.date("%a %d %b %Y %T")..
+		" ["..BatteryLevel().."]", true)
+	renderUtf8Text(fb.bb, 10, 15+6+22, face,
+		"Gamma:"..tostring(self.globalgamma)..", "..
+		tostring(page_width).."x"..tostring(page_height)..", "..
+		tostring(page_dpi).."dpi", true)
+
+	-- display reading progress on bottom of page
+	local ypos = height - 50
+	fb.bb:paintRect(0, ypos, width, 50, 0)
+	ypos = ypos + 15
+	local cur_section = self:getTocTitleOfCurrentPage()
+	if cur_section ~= "" then
+		cur_section = "Sec: "..cur_section
+	end
+	renderUtf8Text(fb.bb, 10, ypos+6, face,
+		"Page: "..self.pageno.."/"..numpages.."   "..cur_section, true)
+
+	ypos = ypos + 15
+	blitbuffer.progressBar(fb.bb, 10, ypos, width-20, 15,
+							5, 4, load_percent, 8)
+	local nsecs, nusecs = util.gettime()
+	local diff = (nsecs - secs)*1000000 + nusecs - usecs
+	print("DJVUReader:_drawReadingInfo(): "..tostring(diff).." us")
+end
+--]]

--- a/unireader.lua
+++ b/unireader.lua
@@ -2317,9 +2317,9 @@ function UniReader:addAllCommands()
 		end)
 	-- NuPogodi, 03.09.12 : moved the exit commands from here to the end of hotkey list 
 	self.commands:addGroup("vol-/+",{Keydef:new(KEY_VPLUS,nil),Keydef:new(KEY_VMINUS,nil)},
-		"decrease/increase gamma 25%",
+		"decrease/increase gamma 10%",
 		function(unireader,keydef)
-			unireader:modifyGamma(keydef.keycode==KEY_VPLUS and 1.25 or 0.8)
+			unireader:modifyGamma(keydef.keycode==KEY_VPLUS and 1.1 or 0.9)
 		end)
 	--numeric key group
 	local numeric_keydefs = {}


### PR DESCRIPTION
The DjVu info shown in the status line includes:
1. Physical page dimensions.
2. Current value of gamma and (in square brackets) the value of the
display for which the page was designed.
3. Page resolution (in dpi).
4. Page type.
For the end-user probably the most useful bit is the page type as it
helps him decide which rendering mode to choose for this page (and also
explains why he can't see anything on the page --- e.g. when rendering
some COMPOUND or PHOTO pages in B&W mode). For the developer the
physical page dimensions are also interesting as they allow to estimate
the amount of time needed for page decoding and cache efficiency.

Oh, and also I changed the order of error checking and page/document decoding as mentioned in #373.
