### PR TITLE
Fixed search in history with empty pattern (from NuPogodi).

### DIFF
--- a/filehistory.lua
+++ b/filehistory.lua
@@ -201,6 +201,8 @@ function FileHistory:addAllCommands()
 			self.keywords = InputBox:input(G_height - 100, 100, "Search:", old_keywords)
 			if self.keywords then
 				self:setSearchResult(self.keywords)
+			else
+				self.keywords = old_keywords
 			end
 			if #self.result < 1 then
 				InfoMessage:inform("No hits! Try another keyword. ", 2000, 1, MSG_WARN,


### PR DESCRIPTION
From @NuPogodi  --- the fix for the crash when searching in history list with empty pattern.
