### PR TITLE
Switch to new InfoMessage API (from NuPogodi).

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -2,6 +2,7 @@ require "font"
 require "unireader"
 require "inputbox"
 require "selectmenu"
+require "dialog"
 
 CREReader = UniReader:new{
 	pos = nil,
@@ -210,7 +211,6 @@ end
 
 function CREReader:gotoTocEntry(entry)
 	self:goto(entry.xpointer, nil, "xpointer")
-	--self:redrawCurrentPage()
 end
 
 function CREReader:nextView()
@@ -244,8 +244,7 @@ function CREReader:showJumpHist()
 	end
 
 	if #menu_items == 0 then
-		showInfoMsgWithDelay(
-			"No jump history found.", 2000, 1)
+		InfoMessage:inform("No jump history found ", 2000, 1, MSG_WARN)
 	else
 		-- if cur points to head, draw entry for current page
 		if self.jump_history.cur > #self.jump_history then
@@ -308,8 +307,7 @@ function CREReader:showBookMarks()
 			.." "..v.notes.." @ "..v.datetime)
 	end
 	if #menu_items == 0 then
-		showInfoMsgWithDelay(
-			"No bookmark found.", 2000, 1)
+		InfoMessage:inform("No bookmark found ", 2000, 1, MSG_WARN)
 	else
 		local bkmk_menu = SelectMenu:new{
 			menu_title = "Bookmarks",
@@ -351,7 +349,7 @@ function CREReader:gotoPrevNextTocEntry(direction)
 		self:fillToc()
 	end
 	if #self.toc == 0 then
-		showInfoMsgWithDelay("No Table of Contents", 1500, 1)
+		InfoMessage:inform("No Table of Contents ", 1500, 1, MSG_WARN)
 		return
 	end
 	-- search for current TOC-entry
@@ -457,7 +455,6 @@ function CREReader:adjustCreReaderCommands()
 	self.commands:add(KEY_K, nil, "K",
 		"rotate screen counterclockwise",
 		function(self)
-			InfoMessage:show("Rotating counterclockwise ", 0)
 			local prev_xpointer = self.doc:getXPointer()
 			Screen:screenRotate("anticlockwise")
 			G_width, G_height = fb:getSize()
@@ -469,7 +466,6 @@ function CREReader:adjustCreReaderCommands()
 	self.commands:add(KEY_J, nil, "J",
 		"rotate screen clockwise",
 		function(self)
-			InfoMessage:show("Rotating clockwise ", 0)
 			local prev_xpointer = self.doc:getXPointer()
 			Screen:screenRotate("clockwise")
 			G_width, G_height = fb:getSize()
@@ -483,10 +479,8 @@ function CREReader:adjustCreReaderCommands()
 		"scroll to previous/next chapter",
 		function(self)
 			if keydef.keycode == KEY_FW_UP then
-				--InfoMessage:show("Jumping to previous chapter ", 0)
 				self:gotoPrevNextTocEntry(-1)
 			else
-				--InfoMessage:show("Jumping to next chapter ", 0)
 				self:gotoPrevNextTocEntry(1)
 			end
 		end
@@ -498,10 +492,8 @@ function CREReader:adjustCreReaderCommands()
 		"scroll "..scrollpages.." pages backwards/forward",
 		function(self)
 			if keydef.keycode == KEY_FW_LEFT then
-				--InfoMessage:show("Scrolling "..scrollpages.." pages backwards ", 0)
 				self:goto(math.max(0, self.pos - scrollpages*G_height))
 			else
-				--InfoMessage:show("Scrolling "..scrollpages.." pages forward ", 0)
 				self:goto(math.min(self.pos + scrollpages*G_height, self.doc:getFullHeight()-G_height))
 			end
 		end
@@ -512,14 +504,13 @@ function CREReader:adjustCreReaderCommands()
 		"increase/decrease font size",
 		function(self)
 			local delta = 1
-			local change = "Increase"
+			local change = "Increasing"
 			if keydef.keycode == KEY_PGBCK or keydef.keycode == KEY_LPGBCK then
-			   delta = -1
-			   change = "Decrease"
+				delta = -1
+				change = "Decreasing"
 			end
 			self.font_zoom = self.font_zoom + delta
-			InfoMessage:show(change.." font size to "..self.font_zoom, 0)
-			-- NuPogodi, 18.08.12: XPointer-method to restore position
+			InfoMessage:inform(change.." font size to "..self.font_zoom..". ", nil, 1, MSG_AUX)
 			Debug("font zoomed to", self.font_zoom)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:zoomFont(delta)
@@ -538,9 +529,8 @@ function CREReader:adjustCreReaderCommands()
 				self.line_space_percent = self.line_space_percent + 10
 				self.line_space_percent = math.min(self.line_space_percent, 200)
 			end
-			InfoMessage:show("Line spacing "..self.line_space_percent.."%", 0)
+			InfoMessage:inform("Changing line space to "..self.line_space_percent.."% ", nil, 1, MSG_AUX)
 			Debug("line spacing set to", self.line_space_percent)
-			-- NuPogodi, 18.08.12: XPointer-method to restore position
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:setDefaultInterlineSpace(self.line_space_percent)
 			self:goto(prev_xpointer, nil, "xpointer")
@@ -550,8 +540,8 @@ function CREReader:adjustCreReaderCommands()
 	for i=1,10 do
 		numeric_keydefs[i]=Keydef:new(KEY_1+i-1, nil, tostring(i%10))
 	end
-	self.commands:addGroup("[1..0]", numeric_keydefs,
-		"jump to <key>*10% of document",
+	self.commands:addGroup("[1, 2 .. 9, 0]",numeric_keydefs,
+		"jump to 0%, 10% .. 90%, 100% of document",
 		function(self, keydef)
 			Debug('jump to position: '..
 				math.floor(self.doc:getFullHeight()*(keydef.keycode-KEY_1)/9)..
@@ -578,10 +568,6 @@ function CREReader:adjustCreReaderCommands()
 	self.commands:add({KEY_F, KEY_AA}, nil, "F",
 		"change document font",
 		function(self)
-			--[[ NuPogodi, 18.08.12:
-			1.	removed excessive saving [saveCurrentBB()] and restoring [restoreFromSavedBB()]
-				the screen, respectively, before & after calling 'fonts_menu'
-			2.	used XPointer-based method to restore position after document rescaling ]]
 			local face_list = cre.getFontFaces()
 			-- define the current font in face_list 
 			local item_no = 0
@@ -597,7 +583,7 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			if item_no then
 				Debug(face_list[item_no])
-				InfoMessage:show("Redrawing with "..face_list[item_no], 0)
+				InfoMessage:inform("Redrawing with "..face_list[item_no].." ", nil, 1, MSG_AUX)
 				self.doc:setFontFace(face_list[item_no])
 				self.font_face = face_list[item_no]
 			end
@@ -609,16 +595,15 @@ function CREReader:adjustCreReaderCommands()
 		function(self)
 			self.default_font = self.font_face
 			G_reader_settings:saveSetting("cre_font", self.font_face)
-			showInfoMsgWithDelay("Default document font set", 2000, 1)
+			InfoMessage:inform("Default document font set ", 2000, 1, MSG_WARN,
+				"Default document font is saved")
 		end
 	)
 	self.commands:add(KEY_F, MOD_ALT, "F",
-		--[[ NuPogodi, 18.08.12: 1. Changed a description to be shown in helppage
-		2. Added message to user; 3. Improved a method to restore position ]]
 		"toggle font-weight: bold <> normal",
 		function(self)
 			
-			InfoMessage:show("Changing font-weight ", 0)
+			InfoMessage:inform("Changing font-weight...", nil, 1, MSG_AUX)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:toggleFontBolder()
 			self:goto(prev_xpointer, nil, "xpointer")
@@ -629,9 +614,9 @@ function CREReader:adjustCreReaderCommands()
 		function(self)
 			ok = self:addBookmark(self.doc:getXPointer())
 			if not ok then
-				showInfoMsgWithDelay("Page already marked!", 2000, 1)
+				InfoMessage:inform("Page already marked ", 1500, 1, MSG_WARN)
 			else
-				showInfoMsgWithDelay("Page marked.", 2000, 1)
+				InfoMessage:inform("Page marked ", 1500, 1, MSG_WARN)
 			end
 		end
 	)
@@ -651,7 +636,7 @@ function CREReader:adjustCreReaderCommands()
 				self.jump_history.cur = prev_jump_no
 				self:goto(self.jump_history[prev_jump_no].page, true, "xpointer")
 			else
-				showInfoMsgWithDelay("Already first jump!", 2000, 1)
+				InfoMessage:inform("Already first jump ", 2000, 1, MSG_WARN)
 			end
 		end
 	)
@@ -663,7 +648,7 @@ function CREReader:adjustCreReaderCommands()
 				self.jump_history.cur = next_jump_no
 				self:goto(self.jump_history[next_jump_no].page, true, "xpointer")
 			else
-				showInfoMsgWithDelay("Already last jump!", 2000, 1)
+				InfoMessage:inform("Already last jump ", 2000, 1, MSG_WARN)
 			end
 		end
 	)
@@ -677,7 +662,7 @@ function CREReader:adjustCreReaderCommands()
 			end
 			cre.setGammaIndex(self.gamma_index+delta)
 			self.gamma_index = cre.getGammaIndex()
-			InfoMessage:show("Redraw with gamma = "..self.gamma_index, 1) -- no delay
+			InfoMessage:inform("Changing gamma to "..self.gamma_index..". ", nil, 1, MSG_AUX)
 			self:redrawCurrentPage()
 		end
 	)
@@ -722,12 +707,11 @@ function CREReader:searchHighLight(search)
 	if found then
 		self.pos = pos -- first metch position
 		self:redrawCurrentPage()
-		showInfoMsgWithDelay( found.." hits '"..search.."' pos "..pos, 2000, 1)
+		InfoMessage:inform( found.." hits '"..search.."' pos "..pos, 2000, 1, MSG_WARN)
 	else
-		showInfoMsgWithDelay( "'"..search.."' not found in document", 2000, 1)
+		InfoMessage:inform( "'"..search.."' not found in document ", 2000, 1, MSG_WARN)
 	end
 
 	self.last_search.search = search
 
 end
-

--- a/filehistory.lua
+++ b/filehistory.lua
@@ -205,8 +205,8 @@ function FileHistory:addAllCommands()
 				self.keywords = old_keywords
 			end
 			if #self.result < 1 then
-				InfoMessage:inform("No hits! Try another keyword. ", 2000, 1, MSG_WARN,
-					"The search has given no results! Please, try another keyword.")
+				InfoMessage:inform("No search hits ", 2000, 1, MSG_WARN,
+					"The search has given no results")
 				-- restoring the original data
 				self.result = old_data
 				self.items = #self.result
@@ -266,7 +266,7 @@ function FileHistory:addAllCommands()
 			end
 		end
 	)
-	self.commands:add({KEY_SPACE}, nil, "Space",
+	self.commands:add(KEY_SPACE, nil, "Space",
 		"refresh page manually",
 		function(self)
 			self.pagedirty = true
@@ -287,7 +287,7 @@ function FileHistory:choose(keywords)
 
 	-- NuPogodi, 30.09.12: immediate quit (no redraw), if empty
 	if self:setSearchResult(keywords) < 1 then
-		InfoMessage:inform("No reading history! ", 2000, 1, MSG_WARN, "The reading history is empty!")
+		InfoMessage:inform("No reading history ", 2000, 1, MSG_WARN, "The reading history is empty!")
 		return nil
 	end
 

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -63,7 +63,7 @@ function FileInfo:formatDiskSizeInfo()
 end
 
 function FileInfo:getFolderContent()
-	InfoMessage:show("Scanning folder...", 1)
+	InfoMessage:inform("Scanning folder...", nil, 1, MSG_AUX)
 	local tmp = io.popen('du -a \"'..self.pathfile..'\"', "r")
 	local dirs, files, books, size, name, output, ftype, j = -1, 0, 0, 0
 	for output in tmp:lines() do
@@ -214,7 +214,7 @@ end
 
 function FileInfo:addAllCommands()
 	self.commands = Commands:new{}
-	self.commands:add({KEY_SPACE}, nil, "Space",
+	self.commands:add(KEY_SPACE, nil, "Space",
 		"refresh page manually",
 		function(self)
 			self.pagedirty = true
@@ -227,7 +227,7 @@ function FileInfo:addAllCommands()
 			self.pagedirty = true
 		end
 	)
-	self.commands:add({KEY_F, KEY_AA}, nil, "F",
+	self.commands:add({KEY_F, KEY_AA}, nil, "F, Aa",
 		"change font faces",
 		function(self)
 			Font:chooseFonts()
@@ -242,7 +242,7 @@ function FileInfo:addAllCommands()
 			self.pagedirty = true
 		end
 	)
-	self.commands:add({KEY_BACK, KEY_FW_LEFT}, nil, "Back",
+	self.commands:add({KEY_BACK, KEY_FW_LEFT}, nil, "Back, FW-Left",
 		"back",
 		function(self)
 			return "break"

--- a/unireader.lua
+++ b/unireader.lua
@@ -3,6 +3,7 @@ require "settings"
 require "selectmenu"
 require "commands"
 require "helppage"
+require "dialog"
 
 UniReader = {
 	-- "constants":
@@ -130,7 +131,7 @@ end
 
 function UniReader:init()
 	-- initialize commands
-	InfoMessage:show("Registering fonts...", 1)
+	InfoMessage:inform("Registering fonts...", nil, 1, MSG_AUX)
 	self:addAllCommands()
 end
 
@@ -387,7 +388,7 @@ end
 function UniReader:startHighLightMode()
 	local t = self:getText(self.pageno)
 	if not t or #t == 0 then
-		showInfoMsgWithDelay("No text available", 1000, 1);
+		InfoMessage:inform("No text available ", 1000, 1, MSG_WARN);
 		return nil
 	end
 
@@ -398,7 +399,7 @@ function UniReader:startHighLightMode()
 			end
 		end
 
-		showInfoMsgWithDelay("No visible text", 1000, 1);
+		InfoMessage:inform("No visible text ", 1000, 1, MSG_WARN);
 		Debug("_findFirstWordInView none found in", t)
 
 		return nil
@@ -1607,7 +1608,7 @@ end
 function UniReader:modifyGamma(factor)
 	Debug("modifyGamma, gamma=", self.globalgamma, " factor=", factor)
 	self.globalgamma = self.globalgamma * factor;
-	InfoMessage:show("New gamma = "..self.globalgamma, 1) -- we don't want delay here
+	InfoMessage:inform("Changing gamma to "..self.globalgamma..". ", nil, 1, MSG_AUX)
 	self:redrawCurrentPage()
 end
 
@@ -1825,7 +1826,7 @@ function UniReader:showToc()
 	end
 
 	if #self.toc == 0 then
-		showInfoMsgWithDelay("No Table of Contents", 1500, 1)
+		InfoMessage:inform("No Table of Contents ", 1500, 1, MSG_WARN)
 		return self:redrawCurrentPage()
 	end
 
@@ -1844,7 +1845,7 @@ function UniReader:showToc()
 			local toc_entry = self.toc[self.toc_curidx_to_x[ret_code]]
 			local pagenum = toc_entry.page
 			if pagenum < 1 or pagenum > self.doc:getPages() then
-				showInfoMsgWithDelay("External links unsupported", 1500, 1)
+				InfoMessage:inform("External links unsupported ", 1500, 1, MSG_WARN)
 				self.toc_curitem = ret_code
 			else
 				return self:gotoTocEntry(toc_entry)
@@ -1883,7 +1884,7 @@ function UniReader:showJumpHist()
 	end
 
 	if #menu_items == 0 then
-		showInfoMsgWithDelay("No jump history found.", 2000, 1)
+		InfoMessage:inform("No jump history found ", 2000, 1, MSG_WARN)
 	else
 		-- if cur points to head, draw entry for current page
 		if self.jump_history.cur > #self.jump_history then
@@ -1920,7 +1921,7 @@ function UniReader:showBookMarks()
 			"Page "..v.page.." "..v.notes.." @ "..v.datetime)
 	end
 	if #menu_items == 0 then
-		return showInfoMsgWithDelay("No bookmarks found", 1500, 1)
+		return InfoMessage:inform("No bookmarks found ", 1500, 1, MSG_WARN)
 	end
 	while true do
 		bm_menu = SelectMenu:new{
@@ -1983,7 +1984,7 @@ function UniReader:showHighLight()
 	end
 
 	if #menu_items == 0 then
-		return showInfoMsgWithDelay("No HighLights found", 1000, 1)
+		return InfoMessage:inform("No HighLights found ", 1000, 1, MSG_WARN)
 	end
 
 	while true do
@@ -2090,14 +2091,14 @@ function UniReader:searchHighLight(search)
 
 	self:goto(self.pageno) -- show highlights, remove input
 	if found > 0 then
-		showInfoMsgWithDelay( found.." hits '"..search.."' page "..self.pageno, 2000, 1)
+		InfoMessage:inform( found.." hits '"..search.."' page "..self.pageno, 2000, 1, MSG_WARN)
 		self.last_search = {
 			pageno = self.pageno,
 			search = search,
 			hits = found,
 		}
 	else
-		showInfoMsgWithDelay( "'"..search.."' not found in document", 2000, 1)
+		InfoMessage:inform( "'"..search.."' not found in document ", 2000, 1, MSG_WARN)
 	end
 
 	self.highlight = old_highlight -- will not remove search highlights until page refresh
@@ -2269,15 +2270,15 @@ function UniReader:addAllCommands()
 			if keydef.keycode == KEY_PGFWD or keydef.keycode == KEY_LPGFWD then
 				unireader.step_manual_zoom = unireader.step_manual_zoom * 2
 				self.settings:saveSetting("step_manual_zoom", self.step_manual_zoom)
-				--showInfoMsgWithDelay("New zoom step is "..unireader.step_manual_zoom.."%. ", 2000, 1)
+				InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", 2000, 1, MSG_WARN)
 			else
 				local minstep = 1
 				if unireader.step_manual_zoom > 2*minstep then
 					unireader.step_manual_zoom = unireader.step_manual_zoom / 2
 					self.settings:saveSetting("step_manual_zoom", self.step_manual_zoom)
-					--showInfoMsgWithDelay("New zoom step is "..unireader.step_manual_zoom.."%. ", 2000, 1)
+					InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", 2000, 1, MSG_WARN)
 				else
-					showInfoMsgWithDelay("Minimum zoom step is "..minstep.."%. ", 2000, 1)
+					InfoMessage:inform("Minimum zoom step is "..minstep.."%. ", 2000, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -2297,7 +2298,7 @@ function UniReader:addAllCommands()
 				unireader.jump_history.cur = prev_jump_no
 				unireader:goto(unireader.jump_history[prev_jump_no].page, true)
 			else
-				showInfoMsgWithDelay("Already first jump!", 2000, 1)
+				InfoMessage:inform("Already first jump ", 2000, 1, MSG_WARN)
 			end
 		end)
 	self.commands:add(KEY_BACK,MOD_SHIFT,"Back",
@@ -2312,10 +2313,9 @@ function UniReader:addAllCommands()
 					unireader.jump_history.cur = unireader.jump_history.cur + 1
 				end
 			else
-				showInfoMsgWithDelay("Already last jump!", 2000, 1)
+				InfoMessage:inform("Already last jump ", 2000, 1, MSG_WARN)
 			end
 		end)
-	-- NuPogodi, 03.09.12 : moved the exit commands from here to the end of hotkey list 
 	self.commands:addGroup("vol-/+",{Keydef:new(KEY_VPLUS,nil),Keydef:new(KEY_VMINUS,nil)},
 		"decrease/increase gamma 10%",
 		function(unireader,keydef)
@@ -2325,7 +2325,7 @@ function UniReader:addAllCommands()
 	local numeric_keydefs = {}
 	for i=1,10 do numeric_keydefs[i]=Keydef:new(KEY_1+i-1,nil,tostring(i%10)) end
 	self.commands:addGroup("[1, 2 .. 9, 0]",numeric_keydefs,
-		"jump to 10%, 20% .. 90%, 100% of document",
+		"jump to 0%, 10% .. 90%, 100% of document",
 		function(unireader,keydef)
 			Debug('jump to page:', math.max(math.floor(unireader.doc:getPages()*(keydef.keycode-KEY_1)/9),1), '/', unireader.doc:getPages())
 			unireader:goto(math.max(math.floor(unireader.doc:getPages()*(keydef.keycode-KEY_1)/9),1))
@@ -2436,9 +2436,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			ok = unireader:addBookmark(self.pageno)
 			if not ok then
-				showInfoMsgWithDelay("Page already marked!", 1500, 1)
+				InfoMessage:inform("Page already marked ", 1500, 1, MSG_WARN)
 			else
-				showInfoMsgWithDelay("Page marked", 1500, 1)
+				InfoMessage:inform("Page marked ", 1500, 1, MSG_WARN)
 			end
 		end)
 	self.commands:add(KEY_B,MOD_SHIFT,"B",
@@ -2449,11 +2449,15 @@ function UniReader:addAllCommands()
 	self.commands:add(KEY_J,MOD_SHIFT,"J",
 		"rotate 10° clockwise",
 		function(unireader)
+			-- NuPogodi, 29.09.12: added MSG_AUX -- not sure
+			InfoMessage:inform("Rotating 10° clockwise...", nil, 1, MSG_AUX)
 			unireader:setRotate( unireader.globalrotate + 10 )
 		end)
 	self.commands:add(KEY_J,nil,"J",
 		"rotate screen 90° clockwise",
 		function(unireader)
+			-- NuPogodi, 29.09.12: added MSG_AUX -- not sure
+			InfoMessage:inform("Rotating 90° clockwise...", nil, 1, MSG_AUX)
 			unireader:screenRotate("clockwise")
 			if self.globalzoom_mode == self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN then
 				self:setglobalzoom_mode(self.ZOOM_FIT_TO_CONTENT_WIDTH)
@@ -2464,11 +2468,15 @@ function UniReader:addAllCommands()
 	self.commands:add(KEY_K,MOD_SHIFT,"K",
 		"rotate 10° counterclockwise",
 		function(unireader)
+			-- NuPogodi, 29.09.12: added MSG_AUX -- not sure
+			InfoMessage:inform("Rotating 10° counterclockwise", nil, 1, MSG_AUX)
 			unireader:setRotate( unireader.globalrotate - 10 )
 		end)
 	self.commands:add(KEY_K,nil,"K",
 		"rotate screen 90° counterclockwise",
 		function(unireader)
+			-- NuPogodi, 29.09.12: added MSG_AUX -- not sure
+			InfoMessage:inform("Rotating 90° counterclockwise", nil, 1, MSG_AUX)
 			unireader:screenRotate("anticlockwise")
 			if self.globalzoom_mode == self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN then
 				self:setglobalzoom_mode(self.ZOOM_FIT_TO_CONTENT_WIDTH)
@@ -2497,15 +2505,7 @@ function UniReader:addAllCommands()
 			-- now, perform full screen refresh
 			self.rcount = self.rcountmax
 			self:redrawCurrentPage()
-			--[[ eink will not refresh if nothing is changed on the screen
-			-- so we fake a change here.
-			fb.bb:invertRect(0, 0, 1, 1)
-			fb:refresh(1)
-			fb.bb:invertRect(0, 0, 1, 1)
-			fb:refresh(0)
-			unireader.rcount = 0 ]]
 		end)
-
 	self.commands:add(KEY_Z,nil,"Z",
 		"set crop mode",
 		function(unireader)
@@ -2521,13 +2521,13 @@ function UniReader:addAllCommands()
 			unireader.bbox.enabled = true
 			Debug("bbox", unireader.pageno, unireader.bbox)
 			unireader.globalzoom_mode = unireader.ZOOM_FIT_TO_CONTENT -- use bbox
-			showInfoMsgWithDelay("Manual crop setting saved.", 2000, 1)
+			InfoMessage:inform("Manual crop setting saved. ", 2000, 1, MSG_WARN)
 		end)
 	self.commands:add(KEY_Z,MOD_SHIFT,"Z",
 		"reset crop",
 		function(unireader)
 			unireader.bbox[unireader.pageno] = nil;
-			showInfoMsgWithDelay("Manual crop setting removed.", 2000, 1)
+			InfoMessage:inform("Manual crop setting removed. ", 2000, 1, MSG_WARN)
 			Debug("bbox remove", unireader.pageno, unireader.bbox);
 		end)
 	self.commands:add(KEY_Z,MOD_ALT,"Z",
@@ -2535,9 +2535,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			unireader.bbox.enabled = not unireader.bbox.enabled;
 			if unireader.bbox.enabled then
-				showInfoMsgWithDelay("Manual crop enabled.", 2000, 1)
+				InfoMessage:inform("Manual crop enabled. ", 2000, 1, MSG_WARN)
 			else
-				showInfoMsgWithDelay("Manual crop disabled.", 2000, 1)
+				InfoMessage:inform("Manual crop disabled. ", 2000, 1, MSG_WARN)
 			end
 			Debug("bbox override", unireader.bbox.enabled);
 		end)
@@ -2567,7 +2567,8 @@ function UniReader:addAllCommands()
 
 			fb.bb:invertRect( 0,y_s, G_width,1 )
 			fb.bb:invertRect( x_s,0, 1,G_height )
-			InfoMessage:show(running_corner.." bbox");
+			InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+				running_corner.." bounding box")
 			fb:refresh(1)
 
 			local last_direction = { x = 0, y = 0 }
@@ -2602,7 +2603,8 @@ function UniReader:addAllCommands()
 							Debug("change top-left", bbox, "to", new_bbox)
 							running_corner = "bottom-right"
 							Screen:restoreFromSavedBB()
-							InfoMessage:show(running_corner.." bbox")
+							InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+								running_corner.." bounding box")
 							fb:refresh(1)
 							x_s = x+w
 							y_s = y+h
@@ -2717,7 +2719,7 @@ function UniReader:addAllCommands()
 			x,y,w,h = unireader:getRectInScreen( new_bbox["x0"], new_bbox["y0"], new_bbox["x1"], new_bbox["y1"] )
 			fb.bb:invertRect( x,y, w,h )
 			--fb.bb:invertRect( x+1,y+1, w-2,h-2 ) -- just border?
-			showInfoMsgWithDelay("new page bbox", 2000, 1);
+			InfoMessage:inform("New page bbox ", 2000, 1, MSG_WARN, "New page bounding box")
 			self:redrawCurrentPage()
 
 			self.rcount = self.rcountmax -- force next full refresh
@@ -2839,7 +2841,7 @@ function UniReader:addAllCommands()
 				end
 			end
 		end)
-	-- NuPogodi, 03.09.2012: functions to change panning steps
+	-- functions to change panning steps
 	self.commands:addGroup("Shift + left/right", {Keydef:new(KEY_FW_LEFT,MOD_SHIFT), Keydef:new(KEY_FW_RIGHT,MOD_SHIFT)},
 		"increase/decrease X-panning step",
 		function(unireader,keydef)
@@ -2849,17 +2851,17 @@ function UniReader:addAllCommands()
 				unireader.shift_x = unireader.shift_x * 2
 				if unireader.shift_x >= G_width then
 					unireader.shift_x = G_width
-					showInfoMsgWithDelay("Maximum X-panning step is "..G_width..". ", 2000, 1)
+					InfoMessage:inform("Maximum X-panning step is "..G_width..". ", 2000, 1, MSG_WARN)
 				end
 				self.settings:saveSetting("shift_x", self.shift_x)
-				--showInfoMsgWithDelay("New X-panning step is "..unireader.shift_x..". ", 2000, 1)
+				InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", 2000, 1, MSG_WARN)
 			else
 				if unireader.shift_x >= 2*minstep then
 					unireader.shift_x = math.ceil(unireader.shift_x / 2)
 					self.settings:saveSetting("shift_x", self.shift_x)
-					--showInfoMsgWithDelay("New X-panning step is "..unireader.shift_x..". ", 2000, 1)
+					InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", 2000, 1, MSG_WARN)
 				else
-					showInfoMsgWithDelay("Minimum X-panning step is "..minstep..". ", 2000, 1)
+					InfoMessage:inform("Minimum X-panning step is "..minstep..". ", 2000, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -2872,17 +2874,17 @@ function UniReader:addAllCommands()
 				unireader.shift_y = unireader.shift_y * 2
 				if unireader.shift_y >= G_height then
 					unireader.shift_y = G_height
-					showInfoMsgWithDelay("Maximum Y-panning step is "..G_height..". ", 2000, 1)
+					InfoMessage:inform("Maximum Y-panning step is "..G_height..". ", 2000, 1, MSG_WARN)
 				end
 				self.settings:saveSetting("shift_y", self.shift_y)
-				--showInfoMsgWithDelay("New Y-panning step is "..unireader.shift_y..". ", 2000, 1)
+				InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", 2000, 1, MSG_WARN)
 			else
 				if unireader.shift_y >= 2*minstep then
 					unireader.shift_y = math.ceil(unireader.shift_y / 2)
 					self.settings:saveSetting("shift_y", self.shift_y)
-					--showInfoMsgWithDelay("New Y-panning step is "..unireader.shift_y..". ", 2000, 1)
+					InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", 2000, 1, MSG_WARN)
 				else
-					showInfoMsgWithDelay("Minimum Y-panning step is "..minstep..". ", 2000, 1)
+					InfoMessage:inform("Minimum Y-panning step is "..minstep..". ", 2000, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -2923,7 +2925,7 @@ function UniReader:addAllCommands()
 		function(unireader)
 			local links = unireader:getPageLinks( unireader.pageno )
 			if links == nil or next(links) == nil then
-				showInfoMsgWithDelay("No links on this page", 2000, 1)
+				InfoMessage:inform("No links on this page ", 2000, 1, MSG_WARN)
 			else
 				local font_size = math.ceil( (links[1].y1 - links[1].y0 - 2) * unireader.globalzoom )
 				Debug("font_size",font_size)
@@ -2942,7 +2944,7 @@ function UniReader:addAllCommands()
 				end
 
 				if page_links == 0 then
-					showInfoMsgWithDelay("No links on this page", 2000, 1)
+					InfoMessage:inform("No links on this page ", 2000, 1, MSG_WARN)
 					return
 				end
 
@@ -3026,6 +3028,28 @@ function UniReader:addAllCommands()
 
 				unireader:goto(goto_page)
 
+			end
+		end
+	)
+	-- NuPogodi, 02.10.12: added functions to switch kpdfviewer mode from readers
+	self.commands:add(KEY_M, MOD_ALT, "M",
+		"select reader mode",
+		function(unireader)
+			Screen:saveCurrentBB()
+			FileChooser:changeFileChooserMode()
+			Screen:restoreFromSavedBB()
+		end
+	)
+	self.commands:add(KEY_I, nil, "I",
+		"change the way to inform about events",
+		function(unireader)
+			if FileChooser.filemanager_expert_mode == FileChooser.ROOT_MODE then
+				Screen:saveCurrentBB()
+				InfoMessage:chooseNotificatonMethods()
+				Screen:restoreFromSavedBB()
+			else
+				InfoMessage:inform("Unstable... For experts only ", -1, 1, MSG_WARN,
+					"This function is still under development and available only for experts and beta testers.")
 			end
 		end
 	)


### PR DESCRIPTION
I have started resolving the conflicts between `NuPogodi-InfoMessages` and `master` branches and this PR converts the four files `crereader.lua filehistory.lua fileinfo.lua unireader.lua` to use the new `InfoMessage:inform()` API by @NuPogodi .

Also, contains trivial tidy up of key shortcuts like `{KEY_SPACE}` -> `KEY_SPACE` not worth mentioning or separating into a different commit.
