### PR TITLE
Improvements to filesearcher from NuPogodi

### DIFF
--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -20,6 +20,7 @@ FileSearcher = {
 	page = 0,
 	current = 1,
 	oldcurrent = 1,
+	commands = nil,
 }
 
 function FileSearcher:readDir()
@@ -78,6 +79,7 @@ end
 function FileSearcher:init(search_path)
 	self:setPath(search_path or "/mnt/us/documents")
 	self:addAllCommands()
+	if not self.commands then self:addAllCommands() end
 end
 
 function FileSearcher:prevItem()
@@ -111,39 +113,27 @@ end
 
 function FileSearcher:addAllCommands()
 	self.commands = Commands:new{}
-	self.commands:add(KEY_L, nil, "L",
-		"last documents",
-		function(self)
-			FileHistory:init()
-			FileHistory:choose("")
-			self.pagedirty = true
-		end
-	)
-	self.commands:add(KEY_H, nil, "H",
-		"show help page",
-		function(self)
-			HelpPage:show(0, G_height, self.commands)
-			self.pagedirty = true
-		end
-	) 
-	self.commands:add({KEY_FW_RIGHT, KEY_I}, nil, "joypad right",
-		"document details",
-		function(self)
-			file_entry = self.result[self.perpage*(self.page-1)+self.current]
-			FileInfo:show(file_entry.dir,file_entry.name)
-			self.pagedirty = true
-		end
-	) 
 	self.commands:add(KEY_FW_UP, nil, "joypad up",
-		"goto previous item",
+		"previous item",
 		function(self)
 			self:prevItem()
 		end
 	)
 	self.commands:add(KEY_FW_DOWN, nil, "joypad down",
-		"goto next item",
+		"next item",
 		function(self)
 			self:nextItem()
+		end
+	)
+	-- NuPogodi, 01.10.12: fast jumps to items at positions 10, 20, .. 90, 0% within the list
+	local numeric_keydefs, i = {}
+	for i=1, 10 do numeric_keydefs[i]=Keydef:new(KEY_1+i-1, nil, tostring(i%10)) end
+	self.commands:addGroup("[1, 2 .. 9, 0]", numeric_keydefs,
+		"item at position 0%, 10% .. 90%, 100%",
+		function(self)
+			local target_item = math.ceil(self.items * (keydef.keycode-KEY_1) / 9)
+			self.current, self.page, self.markerdirty, self.pagedirty = 
+				gotoTargetItem(target_item, self.items, self.current, self.page, self.perpage)
 		end
 	)
 	self.commands:add({KEY_PGFWD, KEY_LPGFWD}, nil, ">",
@@ -173,21 +163,71 @@ function FileSearcher:addAllCommands()
 			end
 		end
 	)
+	self.commands:add(KEY_G, nil, "G",
+		"goto page",
+		function(self)
+			local n = math.ceil(self.items / self.perpage)
+			local page = NumInputBox:input(G_height-100, 100, "Page:", "current page "..self.page.." of "..n, true)
+			if pcall(function () page = math.floor(page) end) -- convert string to number
+			and page ~= self.page and page > 0 and page <= n then
+				self.page = page
+				if self.current + (page-1)*self.perpage > self.items then
+					self.current = self.items - (page-1)*self.perpage
+				end
+			end
+			self.pagedirty = true
+		end
+	)
+	self.commands:add(KEY_L, nil, "L",
+		"last documents",
+		function(self)
+			FileHistory:init()
+			FileHistory:choose("")
+			self.pagedirty = true
+		end
+	)
+	self.commands:add(KEY_H, nil, "H",
+		"show help page",
+		function(self)
+			HelpPage:show(0, G_height, self.commands)
+			self.pagedirty = true
+		end
+	) 
+	self.commands:add(KEY_FW_RIGHT, nil, "joypad right",
+		"document details",
+		function(self)
+			local file_entry = self.result[self.perpage*(self.page-1)+self.current]
+			FileInfo:show(file_entry.dir,file_entry.name)
+			self.pagedirty = true
+		end
+	) 
 	self.commands:add(KEY_S, nil, "S",
 		"invoke search inputbox",
 		function(self)
-			old_keywords = self.keywords
+			local old_keywords = self.keywords
 			self.keywords = InputBox:input(G_height - 100, 100,
-				"Search:", old_keywords)
+"Search:", old_keywords)
 			if self.keywords then
+				local old_data = self.result -- be sure that something is found, otherwise restore
+				local old_page, old_current = self.page, self.current
 				self:setSearchResult(self.keywords)
+				if #self.result < 1 then
+					InfoMessage:inform("No search hits ", 2000, 1, MSG_WARN,
+						"The search has given no results ")
+					-- restoring the original data
+					self.result = old_data
+					self.items = #self.result
+					self.page = old_page
+					self.current = old_current
+					self.keywords = old_keywords
+				end
 			else
 				self.keywords = old_keywords
 			end
 			self.pagedirty = true
 		end
 	)
-	self.commands:add({KEY_F, KEY_AA}, nil, "F",
+	self.commands:add({KEY_F, KEY_AA}, nil, "F, Aa",
 		"change font faces",
 		function(self)
 			Font:chooseFonts()
@@ -197,7 +237,7 @@ function FileSearcher:addAllCommands()
 	self.commands:add({KEY_ENTER, KEY_FW_PRESS}, nil, "Enter",
 		"open selected item",
 		function(self)
-			file_entry = self.result[self.perpage*(self.page-1)+self.current]
+			local file_entry = self.result[self.perpage*(self.page-1)+self.current]
 			file_full_path = file_entry.dir .. "/" .. file_entry.name
 
 			openFile(file_full_path)
@@ -210,32 +250,25 @@ function FileSearcher:addAllCommands()
 			self.pagedirty = true
 		end
 	)
-	self.commands:add({KEY_DEL}, nil, "Del",
+	self.commands:add(KEY_DEL, nil, "Del",
 		"delete document",
 		function(self)
-			file_entry = self.result[self.perpage*(self.page-1)+self.current]
+			local pos = self.perpage*(self.page-1)+self.current
+			local file_entry = self.result[pos]
 			local file_to_del = file_entry.dir .. "/" .. file_entry.name
-			InfoMessage:show("Press \'Y\' to confirm... ",0)
-			while true do
-				ev = input.saveWaitForEvent()
-				ev.code = adjustKeyEvents(ev)
-				if ev.type == EV_KEY and ev.value ~= EVENT_VALUE_KEY_RELEASE then
-					if ev.code == KEY_Y then
-						-- delete the file itself
-						os.remove(file_to_del)
-						-- and its history file, if any
-						os.remove(DocToHistory(file_to_del))
-						 -- to avoid showing just deleted file
-						self:init( self.path )
-						self:choose(self.keywords)
-					end
-					self.pagedirty = true
-					break
-				end -- if ev.type == EV_KEY
-			end -- while
+			if InfoMessage.InfoMethod[MSG_CONFIRM] == 0 then -- silent regime
+				self:deleteFoundFile(file_to_del)
+			else
+				InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM,
+					"Press key Y to confirm deleting")
+				if FileChooser:ReturnKey() == KEY_Y then
+					self:deleteFoundFile(file_to_del)
+				end
+			self.pagedirty = true
+			end
 		end
-	)	
-	self.commands:add({KEY_SPACE}, nil, "Space",
+	)
+	self.commands:add(KEY_SPACE, nil, "Space",
 		"refresh page manually",
 		function(self)
 			self.pagedirty = true
@@ -254,11 +287,16 @@ function FileSearcher:choose(keywords)
 	self.pagedirty = true
 	self.markerdirty = false
 
-
+	
 	-- if given keywords, set new result according to keywords.
 	-- Otherwise, display the previous search result.
 	if keywords then
 		self:setSearchResult(keywords)
+	end
+	-- NuPogodi, 30.09.12: immediate quit (no redraw), if empty -- there is nothing to do in empty list anyway
+	if #self.result < 1 then
+		InfoMessage:inform("No search hits found ", nil, 1, MSG_WARN)
+		return nil
 	end
 
 	while true do
@@ -270,30 +308,20 @@ function FileSearcher:choose(keywords)
 			self.markerdirty = true
 			fb.bb:paintRect(0, 0, G_width, G_height, 0)
 
-			-- draw menu title
 			DrawTitle("Search Results for \'"..self.keywords.."\'".." ("..tostring(self.items).." hits)",self.margin_H,0,self.title_H,3,tface)
 			-- draw results
 			local c
-			if self.items == 0 then -- nothing found
-				y = self.title_H + self.spacing * 2
-				renderUtf8Text(fb.bb, self.margin_H, y, cface,
-					"Sorry, no match found.", true)
-				renderUtf8Text(fb.bb, self.margin_H, y + self.spacing, cface,
-					"Please try a different keyword.", true)
-				self.markerdirty = false
-			else -- found something, draw it
-				for c = 1, self.perpage do
-					local i = (self.page - 1) * self.perpage + c
-					if i <= self.items then
-						y = self.title_H + (self.spacing * c) + 4
-						local ftype = string.lower(string.match(self.result[i].name, ".+%.([^.]+)") or "")
-						DrawFileItem(self.result[i].name,self.margin_H,y,ftype)
-					end
+			for c = 1, self.perpage do
+				local i = (self.page - 1) * self.perpage + c
+				if i <= self.items then
+					y = self.title_H + (self.spacing * c) + 4
+					local ftype = string.lower(string.match(self.result[i].name, ".+%.([^.]+)") or "")
+					DrawFileItem(self.result[i].name,self.margin_H,y,ftype)
 				end
 			end
 			-- draw footer
 			all_page = math.ceil(self.items/self.perpage)
-			DrawFooter("Page "..self.page.." of "..all_page,fface,self.foot_H)		
+			DrawFooter("Page "..self.page.." of "..all_page,fface,self.foot_H)
 		end
 
 		if self.markerdirty then
@@ -344,4 +372,21 @@ function FileSearcher:choose(keywords)
 		end -- if
 	end -- while true
 	return nil
+end
+
+function FileSearcher:deleteFoundFile(file_to_del)
+	os.remove(file_to_del)
+	os.remove(DocToHistory(file_to_del))
+	-- NuPogodi, 02.10.12: remove file from self.files WITHOUT rescanning folders
+	local i = 1
+	while i <= #self.files and self.files[i].dir.."/"..self.files[i].name ~= file_to_del do
+		i = i + 1
+	end
+	if i <= #self.files then
+		table.remove(self.files, i)
+		self.items = #self.files
+	end
+	i = self.current - 1 + (self.page-1)*self.perpage
+	self.page = math.ceil(i/self.perpage)
+	self.current = i - (self.page-1)*self.perpage
 end


### PR DESCRIPTION
1. Initialize self.commands only once
2. Corrections to hotkeys: added fast jumps to item at position 0%,
   10%, ... 100% by Alt+Q, W, ... P
3. Added fast jump to page entered via inputbox (by G)
4. Cleanup of function descriptions and to hotkeys.
5. Added a function `deleteFoundFile(full_filename)` used by `KEY_DEL`
   handler.

This PR finishes cleaning up the current mess (i.e. conflicts) between `NuPogodi-InfoMessages` and `master` branch.
