### PR TITLE
Use only Back (not Home) for exiting from Help screens

### DIFF
--- a/helppage.lua
+++ b/helppage.lua
@@ -116,7 +116,7 @@ function HelpPage:show(ypos, height, commands, title)
 					self.page = self.page - 1
 					is_pagedirty = true
 				end
-			elseif ev.code == KEY_BACK or ev.code == KEY_HOME then
+			elseif ev.code == KEY_BACK then
 				return nil
 			end
 		end


### PR DESCRIPTION
It is a bad idea to use too many keys for the same function and also do
this non-uniformly (i.e. not in all contexts). The info at the bottom of
Help screen says "Back to close this page", so only KEY_BACK (but not
KEY_HOME) should serve this purpose. And if the user pressed Home twice
then the whole application would exit, so using Home here is a bad idea.
