### PR TITLE
TTS in EMU and PDF/DjVu info cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Follow these steps:
 		* install popen_noshell sources into subfolder "popen-noshell"
 
 	* automatically fetch thirdparty sources with Makefile:
-		* make sure you have wget, unzip, git and svn installed
+		* make sure you have patch, wget, unzip, git and svn installed
 		* run `make fetchthirdparty`.
 
 * adapt Makefile to your needs

--- a/dialog.lua
+++ b/dialog.lua
@@ -263,7 +263,11 @@ function InfoMessage:getVolumeLevels()
 end	]]
 
 function say(text)
-	os.execute("say \""..text.."\"")
+	if util.isEmulated() == 1 then
+		os.execute("espeak \""..text.."\"")
+	else
+		os.execute("say \""..text.."\"")
+	end
 end
 
 -- The read/write global InfoMessage settings. When properly tested, the

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -100,9 +100,10 @@ function DJVUReader:_drawReadingInfo()
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
 		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k, "..
-		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k, "..
-		os.date("%a %d %b %Y %T")..
-		" ["..BatteryLevel().."]", true)
+		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k", true)
+	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
+	local w = sizeUtf8Text(0, G_width, face, txt, true).x
+	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,
 		"Gm:"..string.format("%.1f",self.globalgamma).." ["..tostring(page_gamma).."], "..
 		tostring(page_width).."x"..tostring(page_height)..", "..

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -70,6 +70,24 @@ function DJVUReader:invertTextYAxel(pageno, text_table)
 	return text_table
 end
 
+function render_mode_string(rm)
+	if (rm == 0) then
+		return "COLOUR"
+	elseif (rm == 1) then
+		return "B&W"
+	elseif (rm == 2) then
+		return "COLOUR ONLY"
+	elseif (rm == 3) then
+		return "MASK ONLY"
+	elseif (rm == 4) then
+		return "COLOUR BG"
+	elseif (rm == 5) then
+		return "COLOUR FG"
+	else
+		return "UNKNOWN"
+	end
+end
+
 function DJVUReader:_drawReadingInfo()
 	local width, height = G_width, G_height
 	local numpages = self.doc:getPages()
@@ -88,7 +106,8 @@ function DJVUReader:_drawReadingInfo()
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,
 		"Gm:"..string.format("%.1f",self.globalgamma).." ["..tostring(page_gamma).."], "..
 		tostring(page_width).."x"..tostring(page_height)..", "..
-		tostring(page_dpi).."dpi, "..page_type, true)
+		tostring(page_dpi).."dpi, "..page_type..", "..
+		render_mode_string(self.render_mode), true)
 
 	-- display reading progress on bottom of page
 	local ypos = height - 50

--- a/unireader.lua
+++ b/unireader.lua
@@ -2122,8 +2122,10 @@ function UniReader:_drawReadingInfo()
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
 		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 )..
-		" "..math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k "..os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]",
-	true)
+		" "..math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k", true)
+	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
+	local w = sizeUtf8Text(0, G_width, face, txt, true).x
+	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 
 	-- display reading progress on bottom of page
 	local ypos = height - 50


### PR DESCRIPTION
1. On the PC in the EMU mode we can run `espeak` command which has the same interface as `say` command on Kindle.
2. It is convenient to show the current DjVu rendering mode alongside the page type in the Menu info
3. It will look much nicer (especially on DXG) if the time+battery info is flushed to the right (both for PDF and DjVu)
