### PR TITLE
Fixes to text rendering functions and their callers.

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -58,14 +58,17 @@ function BatteryLevel()
 end
 
 -- NuPogodi, 29.09.12: avoid using widgets
-function DrawTitle(text,lmargin,y,height,color,font_face)
+function DrawTitle(text, lmargin, y, height, color, font_face)
 	local r = 6	-- radius for round corners
 	color = 3	-- redefine to ignore the input for background color
+
 	fb.bb:paintRect(1, 1, G_width-2, height - r, color)
 	blitbuffer.paintBorder(fb.bb, 1, height/2, G_width-2, height/2, height/2, color, r)
+
 	local t = BatteryLevel() .. os.date(" %H:%M")
 	r = sizeUtf8Text(0, G_width, font_face, t, true).x
 	renderUtf8Text(fb.bb, G_width-r-lmargin, height-10, font_face, t, true)
+
 	r = G_width - r - 2 * lmargin - 10 -- let's leave small gap
 	if sizeUtf8Text(0, G_width, font_face, text, true).x <= r then
 		renderUtf8Text(fb.bb, lmargin, height-10, font_face, text, true)

--- a/rendertext.lua
+++ b/rendertext.lua
@@ -2,11 +2,13 @@ glyphcache_max_memsize = 256*1024 -- 256kB glyphcache
 glyphcache_current_memsize = 0
 glyphcache = {}
 glyphcache_max_age = 4
+
 function glyphCacheClaim(size)
 	if(size > glyphcache_max_memsize) then
 		error("too much memory claimed")
 		return false
 	end
+
 	while glyphcache_current_memsize + size > glyphcache_max_memsize do
 		for k, _ in pairs(glyphcache) do
 			if glyphcache[k].age > 0 then
@@ -19,11 +21,14 @@ function glyphCacheClaim(size)
 			end
 		end
 	end
+
 	glyphcache_current_memsize = glyphcache_current_memsize + size
 	return true
 end
+
 function getGlyph(face, charcode)
 	local hash = glyphCacheHash(face.hash, charcode)
+
 	if glyphcache[hash] == nil then
 		local glyph = face.ftface:renderGlyph(charcode)
 		local size = glyph.bb:getWidth() * glyph.bb:getHeight() / 2 + 32
@@ -36,21 +41,25 @@ function getGlyph(face, charcode)
 	else
 		glyphcache[hash].age = glyphcache_max_age
 	end
+
 	return glyphcache[hash].glyph
 end
+
 function glyphCacheHash(face, charcode)
 	return face..'_'..charcode;
 end
+
 function clearGlyphCache()
 	glyphcache = {}
 	glyphcache_current_memsize = 0
 end
 
 function sizeUtf8Text(x, width, face, text, kerning)
-	if text == nil then
+	if not text then
 		Debug("sizeUtf8Text called without text");
 		return
 	end
+
 	-- may still need more adaptive pen placement when kerning,
 	-- see: http://freetype.org/freetype2/docs/glyphs/glyphs-4.html
 	local pen_x = 0
@@ -61,72 +70,63 @@ function sizeUtf8Text(x, width, face, text, kerning)
 		if pen_x < (width - x) then
 			local charcode = util.utf8charcode(uchar)
 			local glyph = getGlyph(face, charcode)
-			if kerning and prevcharcode then
-				local kern = face.ftface:getKerning(prevcharcode, charcode)
-				pen_x = pen_x + kern
-				--Debug("prev:"..string.char(prevcharcode).." curr:"..string.char(charcode).." kern:"..kern)
-			else
-				--Debug("curr:"..string.char(charcode))
+			if kerning and (prevcharcode ~= 0) then
+				pen_x = pen_x + face.ftface:getKerning(prevcharcode, charcode)
 			end
 			pen_x = pen_x + glyph.ax
 			pen_y_top = math.max(pen_y_top, glyph.t)
 			pen_y_bottom = math.max(pen_y_bottom, glyph.bb:getHeight() - glyph.t)
 			--Debug("ax:"..glyph.ax.." t:"..glyph.t.." r:"..glyph.r.." h:"..glyph.bb:getHeight().." w:"..glyph.bb:getWidth().." yt:"..pen_y_top.." yb:"..pen_y_bottom)
 			prevcharcode = charcode
-		end
-	end
+		end  -- if pen_x < (width -x)
+	end -- for uchar
+
 	return { x = pen_x, y_top = pen_y_top, y_bottom = pen_y_bottom}
 end
 
 function renderUtf8Text(buffer, x, y, face, text, kerning)
-	if text == nil then
+	if not text then
 		Debug("renderUtf8Text called without text");
 		return 0
 	end
+
 	-- may still need more adaptive pen placement when kerning,
 	-- see: http://freetype.org/freetype2/docs/glyphs/glyphs-4.html
 	local pen_x = 0
 	local prevcharcode = 0
+	buffer_width = buffer:getWidth()
 	for uchar in string.gfind(text, "([%z\1-\127\194-\244][\128-\191]*)") do
-		if pen_x < buffer:getWidth() then
+		if pen_x < buffer_width then
 			local charcode = util.utf8charcode(uchar)
 			local glyph = getGlyph(face, charcode)
-			if kerning and prevcharcode then
-				local kern = face.ftface:getKerning(prevcharcode, charcode)
-				pen_x = pen_x + kern
-				--Debug("prev:"..string.char(prevcharcode).." curr:"..string.char(charcode).." pen_x:"..pen_x.." kern:"..kern)
-				buffer:addblitFrom(glyph.bb, x + pen_x + glyph.l, y - glyph.t, 0, 0, glyph.bb:getWidth(), glyph.bb:getHeight())
-			else
-				--Debug(" curr:"..string.char(charcode))
-				buffer:blitFrom(glyph.bb, x + pen_x + glyph.l, y - glyph.t, 0, 0, glyph.bb:getWidth(), glyph.bb:getHeight())
+			if kerning and (prevcharcode ~= 0) then
+				pen_x = pen_x + face.ftface:getKerning(prevcharcode, charcode)
 			end
+			buffer:addblitFrom(glyph.bb, x + pen_x + glyph.l, y - glyph.t, 0, 0, glyph.bb:getWidth(), glyph.bb:getHeight())
 			pen_x = pen_x + glyph.ax
 			prevcharcode = charcode
-		end
-	end
+		end -- if pen_x < buffer_width
+	end -- for uchar
+
 	return pen_x
 end
 
 -- render UTF8 text restricted by width 'w'
 function renderUtf8TextWidth(buffer, x, y, face, text, kerning, w)
-	if text == nil then
+	if not text then
 		Debug("renderUtf8Text called without text");
 		return nil
 	end
+
 	local prevcharcode, pen_x, rest = 0, 0, ""
 	for uchar in string.gfind(text, "([%z\1-\127\194-\244][\128-\191]*)") do
 		if pen_x < w then
 			local charcode = util.utf8charcode(uchar)
 			local glyph = getGlyph(face, charcode)
 			if kerning and prevcharcode then
-				local kern = face.ftface:getKerning(prevcharcode, charcode)
-				pen_x = pen_x + kern
-				--Debug("prev:"..string.char(prevcharcode).." curr:"..string.char(charcode).." pen_x:"..pen_x.." kern:"..kern)
-				buffer:addblitFrom(glyph.bb, x + pen_x + glyph.l, y - glyph.t, 0, 0, glyph.bb:getWidth(), glyph.bb:getHeight())
-			else
-				--Debug(" curr:"..string.char(charcode))
-				buffer:blitFrom(glyph.bb, x + pen_x + glyph.l, y - glyph.t, 0, 0, glyph.bb:getWidth(), glyph.bb:getHeight())
+				pen_x = pen_x + face.ftface:getKerning(prevcharcode, charcode)
 			end
+			buffer:addblitFrom(glyph.bb, x + pen_x + glyph.l, y - glyph.t, 0, 0, glyph.bb:getWidth(), glyph.bb:getHeight())
 			pen_x = pen_x + glyph.ax
 			prevcharcode = charcode
 		else
@@ -134,7 +134,7 @@ function renderUtf8TextWidth(buffer, x, y, face, text, kerning, w)
 			rest = rest .. uchar
 		end
 	end
-	return { leaved = rest, x = pen_x, y = y }
+	return { left = rest, x = pen_x, y = y }
 end
 
 function SplitString(text)
@@ -163,7 +163,7 @@ function renderUtf8Multiline(buffer, x, y, face, text, kerning, w, line_spacing)
 		-- if line_spacing>5 then it seems to be defined in pixels
 		elseif line_spacing>=5 then line_spacing=line_spacing
 		-- and, just for a case, default value
-		else line_spacing = math.ceil(gl.t * 1.75) 
+		else line_spacing = math.ceil(gl.t * 1.75)
 	end
 	-- NuPogodi, 17.07.2012: minor modification to solve issue #214
 	local lx, render = x
@@ -171,18 +171,17 @@ function renderUtf8Multiline(buffer, x, y, face, text, kerning, w, line_spacing)
 		if sizeUtf8Text(lx, buffer:getWidth(), face, words[i], kerning).x < (w - lx + x) then
 			lx = lx + renderUtf8TextWidth(buffer, lx, y, face, words[i], kerning, w - lx + x).x
 		else	-- shift down if it's not the first word in the current line
-			if lx > x then 
+			if lx > x then
 				y = y + line_spacing
 			end
 			lx = x	-- move lx to the line start and draw next word until the last char
 			render = renderUtf8TextWidth(buffer, lx, y, face, words[i], kerning, w-gl.ax)
-			while render.leaved ~= "" do
+			while render.left ~= "" do
 				y = y + line_spacing
-				render = renderUtf8TextWidth(buffer, lx, y, face, render.leaved, kerning, w-gl.ax)
+				render = renderUtf8TextWidth(buffer, lx, y, face, render.left, kerning, w-gl.ax)
 			end
 			lx = lx + render.x
 		end -- if
-	end --for 
+	end --for
 	return { x = x, y = y }
 end
-

--- a/widget.lua
+++ b/widget.lua
@@ -107,7 +107,7 @@ TextWidget = Widget:new({
 function TextWidget:_render()
 	local h = self.face.size * 1.5
 	self._bb = Blitbuffer.new(self._maxlength, h)
-	self._length = renderUtf8Text(self._bb, 0, h*.7, self.face, self.text, self.color)
+	self._length = renderUtf8Text(self._bb, 0, h*.7, self.face, self.text, true)
 end
 
 function TextWidget:getSize()


### PR DESCRIPTION
1. In `widget.lua:TextWidget:_render()` function the last argument (`kerning`) of renderUtf8Text() should be a boolean value.
2. In rendertext.lua the sizeUtf8Text()/renderUtf8text/renderUtf8TextWidth() functions had a flawed logic of checking whether to kern or not.
