### PR TITLE
Show the program version in the Help header.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,9 @@ POPENNSLIB := $(POPENNSDIR)/libpopen_noshell.a
 
 all: kpdfview
 
+VERSION?=$(shell git describe HEAD)
 kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o input.o $(POPENNSLIB) util.o ft.o lfs.o mupdfimg.o $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) djvu.o $(DJVULIBS) cre.o $(CRENGINELIBS)
+	echo $(VERSION) > git-rev
 	$(CC) \
 		$(CFLAGS) \
 		kpdfview.o \
@@ -246,7 +248,6 @@ INSTALL_DIR=kindlepdfviewer
 
 LUA_FILES=alt_getopt.lua commands.lua crereader.lua dialog.lua djvureader.lua extentions.lua filechooser.lua filehistory.lua fileinfo.lua filesearcher.lua font.lua graphics.lua helppage.lua image.lua inputbox.lua keys.lua pdfreader.lua reader.lua rendertext.lua screen.lua selectmenu.lua settings.lua unireader.lua widget.lua
 
-VERSION?=$(shell git describe HEAD)
 customupdate: all
 	# ensure that build binary is for ARM
 	file kpdfview | grep ARM || exit 1
@@ -254,12 +255,11 @@ customupdate: all
 	rm -f kindlepdfviewer-$(VERSION).zip
 	rm -rf $(INSTALL_DIR)
 	mkdir -p $(INSTALL_DIR)/{history,screenshots}
-	echo $(VERSION) > $(INSTALL_DIR)/git-rev
 	cp -p README.md COPYING kpdfview kpdf.sh $(LUA_FILES) $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/data
 	cp -rpL data/*.css $(INSTALL_DIR)/data
 	cp -rpL fonts $(INSTALL_DIR)
-	cp -r resources $(INSTALL_DIR)
+	cp -r git-rev resources $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/fonts/host
 	zip -9 -r kindlepdfviewer-$(VERSION).zip $(INSTALL_DIR) launchpad/ kite/
 	rm -rf $(INSTALL_DIR)

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -498,7 +498,8 @@ function FileChooser:addAllCommands()
 	self.commands:add(KEY_H,nil,"H",
 		"show help page",
 		function(self)
-			HelpPage:show(0, G_height, self.commands)
+			local title="Hotkeys  "..G_program_version
+			HelpPage:show(0, G_height, self.commands, title)
 			self.pagedirty = true
 		end
 	)

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -498,8 +498,7 @@ function FileChooser:addAllCommands()
 	self.commands:add(KEY_H,nil,"H",
 		"show help page",
 		function(self)
-			local title="Hotkeys  "..G_program_version
-			HelpPage:show(0, G_height, self.commands, title)
+			HelpPage:show(0, G_height, self.commands, "Hotkeys  "..G_program_version)
 			self.pagedirty = true
 		end
 	)

--- a/reader.lua
+++ b/reader.lua
@@ -99,6 +99,15 @@ if optarg["G"] ~= nil then
 	globalgamma = optarg["G"]
 end
 
+local vfile = io.open("git-rev", "r")
+if vfile then
+	G_program_version = vfile:read("*a") or "?"
+	G_program_version = G_program_version:gsub("[\n\r]+", "")
+	vfile.close()
+else
+	G_program_version = "(unknown version)"
+end
+
 if util.isEmulated()==1 then
 	input.open("")
 	-- SDL key codes


### PR DESCRIPTION
1. On startup read the file git-rev if it exists and initialize a new global
   G_program_version.
2. In filechooser's help page's header show the program version.
   This helps to easily identify what version of KPV the user is running without
   asking him to cat git-rev file manually.
