### PR TITLE
No need for page redraw in UniReader:addBookmark()

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1469,7 +1469,6 @@ function UniReader:addJump(pageno)
 	end
 	table.insert(self.jump_history, jump_item)
 	self.jump_history.cur = #self.jump_history + 1
-	--self:redrawCurrentPage()
 	return true
 end
 
@@ -1507,7 +1506,6 @@ function UniReader:addBookmark(pageno)
 	table.sort(self.bookmarks, function(a,b)
 		return self:isBookmarkInSequence(a, b)
 	end)
-	self:redrawCurrentPage()
 	return true
 end
 


### PR DESCRIPTION
The call to self:redrawCurrentPage() in UniReader:addBookmark() comes
from the days when this function was causing a "Retrieving TOC..."
message via getTocTitleByPage()->fillToc() codepath. Now that message is
gone so we should kill the redraw as well.

Thanks to @dracodoc for finding and reporting this bug (see the issue #390)
