### PR TITLE
Bugfix: count books like BOOK.PDF and BOOK.DJVU

### DIFF
--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -74,7 +74,7 @@ function FileInfo:getFolderContent()
 		if j == "file" then
 			files = files + 1
 			ftype = string.match(name, ".+%.([^.]+)")
-			if ftype and ext:getReader(ftype) then
+			if ftype and ext:getReader(string.lower(ftype)) then
 				books = books + 1
 			end
 		elseif j == "directory" then


### PR DESCRIPTION
In the function `FileInfo:getFolderContent()` we need to lowercase the extension before deciding if it is a book or not --- otherwise files like `BOOK.PDF` and `BOOK.DJVU` are not counted as books.
