### PR TITLE
Cleanup of getUsedBBox() function.

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -229,13 +229,10 @@ static int getPageSize(lua_State *L) {
 
 /* unsupported so fake it */
 static int getUsedBBox(lua_State *L) {
-	DjvuPage *page = (DjvuPage*) luaL_checkudata(L, 1, "djvupage");
-
 	lua_pushnumber(L, (double)0.01);
 	lua_pushnumber(L, (double)0.01);
 	lua_pushnumber(L, (double)-0.01);
 	lua_pushnumber(L, (double)-0.01);
-
 	return 4;
 }
 


### PR DESCRIPTION
The function `djvu.c:getUsedBBox()` does not need to perform any operations on the `DjvuPage` structure, so there is no need to obtain it from Lua.
