### PR TITLE
Validate DjVu magic string before opening.

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -2,9 +2,23 @@ require "unireader"
 
 DJVUReader = UniReader:new{}
 
+-- check DjVu magic string to validate
+function validDJVUFile(filename)
+	f = io.open(filename, "r")
+	if not f then return false end
+	local magic = f:read(8)
+	f:close()
+	if not magic or magic ~= "AT&TFORM" then return false end
+	return true
+end
+
 -- open a DJVU file and its settings store
 -- DJVU does not support password yet
 function DJVUReader:open(filename)
+	if not validDJVUFile(filename) then
+		return false, "Not a valid DjVu file"
+	end
+
 	local ok
 	ok, self.doc = pcall(djvu.openDocument, filename, self.cache_document_size)
 	if not ok then


### PR DESCRIPTION
While browsing libdjvu sources I remembered that I always validated DjVu magic string before passing the file to djvulibre. This is because forcing djvulibre errors on open is a bad idea --- it can lead to very strange side effects, such as refusing to open the next (valid!) DjVu file.

So, I have now implemented the same in KPV --- check DjVu magic string before passing it to the proper DjVu :openDocument() method.
I timed the difference between opening with and without validation and it was absolutely negligible (i.e. by far most of the time is spent in DjVu document decoding anyway).
