### PR TITLE
Restrict the value of gamma in the window message.

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1633,7 +1633,7 @@ end
 function UniReader:modifyGamma(factor)
 	Debug("modifyGamma, gamma=", self.globalgamma, " factor=", factor)
 	self.globalgamma = self.globalgamma * factor;
-	InfoMessage:inform("Changing gamma to "..self.globalgamma..". ", nil, 1, MSG_AUX)
+	InfoMessage:inform(string.format("New gamma is %.1f", self.globalgamma), nil, 1, MSG_AUX)
 	self:redrawCurrentPage()
 end
 


### PR DESCRIPTION
In order to make sure that the message is always visible we should not show all the decimal places --- one is more than enough. Otherwise the whole thing is invisible, often enough to be irritating...
