### PR TITLE
Possible fix for the memory corruption issue #401

### DIFF
--- a/rendertext.lua
+++ b/rendertext.lua
@@ -94,7 +94,7 @@ function renderUtf8Text(buffer, x, y, face, text, kerning)
 	-- see: http://freetype.org/freetype2/docs/glyphs/glyphs-4.html
 	local pen_x = 0
 	local prevcharcode = 0
-	buffer_width = buffer:getWidth()
+	local buffer_width = buffer:getWidth()
 	for uchar in string.gfind(text, "([%z\1-\127\194-\244][\128-\191]*)") do
 		if pen_x < buffer_width then
 			local charcode = util.utf8charcode(uchar)


### PR DESCRIPTION
In the function renderUtf8Text() I added a variable `buffer_width` which
was intended to be local but I forgot the keyword `local` in front of
it. This overwrote whatever global `buffer_width` there might be and
caused a serious memory corruption described in issue #401. Although
grepping our *.lua sources did not reveal any `buffer_width` variable I
assume that there is one elsewhere (i.e. Lua's own internal namespace is
"pollutable" by user's code) because this little change definitely does
make an awful amount of difference...
