### PR TITLE
Add git-rev file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cr3cache
 history
 crash.log
 .vimrc
+git-rev
 data
 fonts
 kpdfview


### PR DESCRIPTION
We now generate `git-rev` file in the build directory, so it should be mentioned in `.gitignore` to keep `git status` tidy.
