### PR TITLE
Force the use of bash in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ TTF_FONTS_DIR=$(MUPDFDIR)/fonts
 
 # set this to your ARM cross compiler:
 
+SHELL:=/bin/bash
 CHOST?=arm-none-linux-gnueabi
 CC:=$(CHOST)-gcc
 CXX:=$(CHOST)-g++


### PR DESCRIPTION
On some distributions (e.g. Ubuntu) the shell used for scripts is dash, not bash and we explicitly rely on bash's features in the Makefile, so we must guarantee that we are running with bash (not dash or anything else).
