### PR TITLE
Two bugfixes: issues #419 and #420

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -191,7 +191,7 @@ function FileChooser:setPath(newPath)
 		end
 
 		if search_position then
-			-- extract the leaf part of oldPath, i.e. the actual directory name
+			-- extract the base part of oldPath, i.e. the actual directory name
 			local pos, _, oldPathBase = string.find(oldPath, "^.*/(.*)$")
 
 			-- now search for the base part of oldPath among self.dirs[]


### PR DESCRIPTION
1. Rewritten the function `FileChooser:setPath()` to handle returning to the parent directory via ".." entry correctly. Issue #419.
2. Fixed the crash when moving the last file from a directory to the clipboard via Shift-X and then pressing Shift-X on the phantom entry that is left. Issue #420
