### PR TITLE
Free raw_image if it is unsupported.

### DIFF
--- a/pic.c
+++ b/pic.c
@@ -142,8 +142,10 @@ static int openDocument(lua_State *L) {
 			return luaL_error(L, "Cannot convert to grayscale");
 		else
 			doc->image = gray_image;
-	} else
+	} else {
+		free(raw_image);
 		return luaL_error(L, "Unsupported image format");
+	}
 
 	doc->width = width;
 	doc->height = height;

--- a/pic.c
+++ b/pic.c
@@ -133,6 +133,7 @@ static int openDocument(lua_State *L) {
 	if (!raw_image)
 		return luaL_error(L, "Cannot open jpeg file");
 
+	doc->image = NULL;
 	if (components == 1)
 		doc->image = raw_image;
 	else if (components == 3) {


### PR DESCRIPTION
If the number of colour components is neither 1 nor 3 we should remember to free the buffer holding the raw decoded image before returning the error to Lua.
