### PR TITLE
Settings etc

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -1,6 +1,8 @@
 require "unireader"
 
-DJVUReader = UniReader:new{}
+DJVUReader = UniReader:new{
+	show_links_enable = false
+}
 
 -- check DjVu magic string to validate
 function validDJVUFile(filename)

--- a/picviewer.lua
+++ b/picviewer.lua
@@ -1,6 +1,9 @@
 require "unireader"
 
-PICViewer = UniReader:new{}
+PICViewer = UniReader:new{
+	show_overlap_enable = false,
+	show_links_enable = false,
+}
 
 function PICViewer:open(filename)
 	ok, self.doc = pcall(pic.openDocument, filename)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1862,8 +1862,7 @@ function UniReader:showToc()
 	end
 
 	if #self.toc == 0 then
-		InfoMessage:inform("No Table of Contents ", 1500, 1, MSG_WARN)
-		return self:redrawCurrentPage()
+		return InfoMessage:inform("No Table of Contents ", 1500, 1, MSG_WARN)
 	end
 
 	self.toc_curitem = self:findTOCpos()

--- a/unireader.lua
+++ b/unireader.lua
@@ -2982,7 +2982,7 @@ function UniReader:addAllCommands()
 		end
 	)
 	self.commands:add(KEY_L, MOD_SHIFT, "L",
-		"show/hide links on page",
+		"show/hide link underlines",
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
 			if unireader.show_links_enable then

--- a/unireader.lua
+++ b/unireader.lua
@@ -987,8 +987,14 @@ function UniReader:loadSettings(filename)
 		end
 
 		self.rcountmax = self.settings:readSetting("rcountmax") or self.rcountmax
-		self.show_overlap_enable = self.settings:readSetting("show_overlap_enable")
-		self.show_links_enable = self.settings:readSetting("show_links_enable")
+		local tmp = self.settings:readSetting("show_overlap_enable")
+		if tmp ~= nil then
+			self.show_overlap_enable = tmp
+		end
+		tmp = self.settings:readSetting("show_links_enable")
+		if tmp ~= nil then
+			self.show_links_enable = tmp
+		end
 
 		-- other parameters are reader-specific --> @TODO: move to proper place, like loadSpecialSettings()
 		-- since DJVUReader still has no loadSpecialSettings(), just a quick solution is
@@ -2246,6 +2252,8 @@ function UniReader:inputLoop()
 	self.toc_xview = nil
 	self.toc_cview = nil
 	self.toc_curidx_to_x = nil
+	self.show_overlap_enable = true
+	self.show_links_enable = true
 	if self.doc ~= nil then
 		self.doc:close()
 	end
@@ -2978,9 +2986,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
 			if unireader.show_links_enable then
-				InfoMessage:inform("Links on page ON", nil, 1, MSG_AUX)
+				InfoMessage:inform("Link underlines ON", nil, 1, MSG_AUX)
 			else
-				InfoMessage:inform("Links on page OFF", nil, 1, MSG_AUX)
+				InfoMessage:inform("Link underlines OFF", nil, 1, MSG_AUX)
 			end
 			self.settings:saveSetting("show_links_enable", unireader.show_links_enable)
 			self:redrawCurrentPage()


### PR DESCRIPTION
This PR contains two bugfixes, one message text cleanup and one enhancement.

1.When loading boolean settings we have to explicitly check for the return of `nil` from the `self.settings:readSetting()` function and only modify the default if the return value is NOT `nil`.
1. When closing the document we have to reset the settings to defaults, otherwise their values are re-used on the next open.
2. The messages "Links on page ON/OFF" changed to "Link underlines ON/OFF" because the old version gave two false impressions: a) as if the action is pertinent only to the current page (but in fact it is global for the entire document) and b) that we are disabling the links whereas we are only disabling the show of underlines under the links. The new message addresses both issues.
3. For the picture viewer we want to disable showing grey boxes on page overlaps and underlining of the links (because there aren't any). With the first commit in this PR we can override the UniReader's defaults very easily and elegantly.
4. Removed unneeded page redraw from `UniReader:showToc()` which was there from the days of "Retrieving TOC..." message which no longer exists.
