### PR TITLE
PICViewer cleanup

### DIFF
--- a/pic.c
+++ b/pic.c
@@ -37,7 +37,9 @@ typedef struct PicDocument {
 } PicDocument;
 
 typedef struct PicPage {
-	int width, height;
+	int width;
+	int height;
+	uint8_t *image;
 	PicDocument *doc;
 } PicPage;
 
@@ -103,6 +105,7 @@ static int openPage(lua_State *L) {
 
 	page->width = doc->width;
 	page->height = doc->height;
+	page->image = doc->image;
 	page->doc = doc;
 
 	return 1;
@@ -148,8 +151,8 @@ static int drawPage(lua_State *L) {
 	int x_offset = MAX(0, dc->offset_x);
 	int y_offset = MAX(0, dc->offset_y);
 	int x, y;
-	int img_width = page->doc->width;
-	int img_height = page->doc->height;
+	int img_width = page->width;
+	int img_height = page->height;
 	int img_new_width = bb->w;
 	int img_new_height = bb->h;
 	unsigned char adjusted_low[16], adjusted_high[16];
@@ -168,7 +171,7 @@ static int drawPage(lua_State *L) {
 	if (!scaled_image)
 		return 0;
 
-	scaleImage(scaled_image, page->doc->image, img_width, img_height, img_new_width, img_new_height);
+	scaleImage(scaled_image, page->image, img_width, img_height, img_new_width, img_new_height);
 
 	uint8_t *bbptr = bb->data;
 	uint8_t *pmptr = scaled_image;
@@ -195,7 +198,7 @@ static int drawPage(lua_State *L) {
 
 static int getCacheSize(lua_State *L) {
 	PicDocument *doc = (PicDocument*) luaL_checkudata(L, 1, "picdocument");
-	lua_pushnumber(L, doc->width * doc->height * doc->components);
+	lua_pushnumber(L, 0);
 	return 1;
 }
 

--- a/picviewer.lua
+++ b/picviewer.lua
@@ -22,13 +22,13 @@ function PICViewer:_drawReadingInfo()
 	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
-		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k, "..
-		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k", true)
+		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k", true)
 	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
 	local w = sizeUtf8Text(0, width, face, txt, true).x
 	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,
 		"Gm:"..string.format("%.1f",self.globalgamma)..", "..
-		tostring(page_width).."x"..tostring(page_height).."x"..tostring(page_components)..", "..
+		tostring(page_width).."x"..tostring(page_height).."x"..tostring(page_components)..
+		" ("..tostring(math.ceil(page_width*page_height*page_components/1024)).."k), "..
 		string.format("%.1fx", self.globalzoom), true)
 end


### PR DESCRIPTION
1. In `Menu` info don't show document cache as there is no such thing for PICViewer.
2. In `Menu` info show the image size (in K) in brackets next to the resolution as that is where it logically belongs.
3. Report the true size of the document cache (0).
4. Cut down the number of pointer dereferences in drawPage().
