### PR TITLE
Provide :setDefaults() for overriding defaults

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -1,8 +1,10 @@
 require "unireader"
 
-DJVUReader = UniReader:new{
-	show_links_enable = false
-}
+DJVUReader = UniReader:new{}
+
+function DJVUReader:setDefaults()
+	self.show_links_enable = false
+end
 
 -- check DjVu magic string to validate
 function validDJVUFile(filename)

--- a/picviewer.lua
+++ b/picviewer.lua
@@ -1,9 +1,11 @@
 require "unireader"
 
-PICViewer = UniReader:new{
-	show_overlap_enable = false,
-	show_links_enable = false,
-}
+PICViewer = UniReader:new{}
+
+function PICViewer:setDefaults()
+	self.show_overlap_enable = false
+	self.show_links_enable = false
+end
 
 function PICViewer:open(filename)
 	ok, self.doc = pcall(pic.openDocument, filename)

--- a/unireader.lua
+++ b/unireader.lua
@@ -952,8 +952,8 @@ function UniReader:preLoadSettings(filename)
 	self.cache_document_size = self.settings:readSetting("cache_document_size") or self.cache_document_size
 end
 
--- all boolean defaults MUST be initialized here
--- (provided to allow other objects override UniReader's defaults)
+-- all defaults which can be overriden by reader objects
+-- (PDFReader, DJVUReader, etc) must be initialized here.
 function UniReader:setDefaults()
 	self.show_overlap_enable = true
 	self.show_links_enable = true

--- a/unireader.lua
+++ b/unireader.lua
@@ -66,8 +66,8 @@ UniReader = {
 	pan_margin = 5, -- horizontal margin for two-column zoom (in pixels)
 	pan_overlap_vertical = 30,
 	show_overlap = 0,
-	show_overlap_enable = true,
-	show_links_enable = true,
+	show_overlap_enable,
+	show_links_enable,
 
 	-- the document:
 	doc = nil,
@@ -952,6 +952,13 @@ function UniReader:preLoadSettings(filename)
 	self.cache_document_size = self.settings:readSetting("cache_document_size") or self.cache_document_size
 end
 
+-- all boolean defaults MUST be initialized here
+-- (provided to allow other objects override UniReader's defaults)
+function UniReader:setDefaults()
+	self.show_overlap_enable = true
+	self.show_links_enable = true
+end
+
 -- This is a low-level method that can be shared with all readers.
 function UniReader:loadSettings(filename)
 	if self.doc ~= nil then
@@ -987,6 +994,8 @@ function UniReader:loadSettings(filename)
 		end
 
 		self.rcountmax = self.settings:readSetting("rcountmax") or self.rcountmax
+
+		self:setDefaults()
 		local tmp = self.settings:readSetting("show_overlap_enable")
 		if tmp ~= nil then
 			self.show_overlap_enable = tmp
@@ -2251,8 +2260,7 @@ function UniReader:inputLoop()
 	self.toc_xview = nil
 	self.toc_cview = nil
 	self.toc_curidx_to_x = nil
-	self.show_overlap_enable = true
-	self.show_links_enable = true
+	self:setDefaults()
 	if self.doc ~= nil then
 		self.doc:close()
 	end


### PR DESCRIPTION
Because we re-use the same instance of UniReader object (i.e. PDFReader for all pdf files, DJVUReader for all djvu files, CREReader for all ebooks and PICViewer for all images) we have to re-initialize the defaults on closing the document. The clean way to do this which allows to keep the default values in a single place is in a :setDefaults() method which this commit provides, together with the example of usage in DJVUReader and PICViewer.
