### PR TITLE
fix getCurrentPageLinks segfault on links without target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,8 @@ fetchthirdparty:
 	# CREngine patch: change child nodes' type face
 	# @TODO replace this dirty hack  24.04 2012 (houqp)
 	cd kpvcrlib/crengine/crengine/src && \
-		patch -N -p0 < ../../../lvrend_node_type_face.patch || true
+		patch -N -p0 < ../../../lvrend_node_type_face.patch && \
+		patch -N -p3 < ../../../lvdocview-getCurrentPageLinks.patch || true
 	unzip mupdf-thirdparty.zip -d mupdf
 	# dirty patch in MuPDF's thirdparty liby for CREngine
 	cd mupdf/thirdparty/jpeg-*/ && \

--- a/cre.cpp
+++ b/cre.cpp
@@ -17,7 +17,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef DEBUG_CRENGINE
 #define DEBUG_CRENGINE 0
+#endif
 
 extern "C" {
 #include "blitbuffer.h"

--- a/kpvcrlib/lvdocview-getCurrentPageLinks.patch
+++ b/kpvcrlib/lvdocview-getCurrentPageLinks.patch
@@ -1,0 +1,14 @@
+diff --git a/crengine/src/lvdocview.cpp b/crengine/src/lvdocview.cpp
+index e7a355a..e1178de 100755
+--- a/crengine/src/lvdocview.cpp
++++ b/crengine/src/lvdocview.cpp
+@@ -4539,7 +4539,8 @@ void LVDocView::getCurrentPageLinks(ldomXRangeList & list) {
+ 						if (_list[i]->getStart().getNode() == elem)
+ 							return true; // don't add, duplicate found!
+ 					}
+-                                        _list.add(new ldomXRange(elem->getChildNode(0)));
++					ldomNode * node = elem->getChildNode(0);
++					if ( node ) _list.add(new ldomXRange(node));
+ 				}
+ 				return true;
+ 			}


### PR DESCRIPTION
It's also reported to upstream at:

https://sourceforge.net/tracker/?func=detail&aid=3577117&group_id=191284&atid=936756
