### PR TITLE
Increase the max value of rcountmax to 200

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -2555,13 +2555,13 @@ function UniReader:addAllCommands()
 		"set full screen refresh count",
 		function(unireader)
 			local count = NumInputBox:input(G_height-100, 100,
-				"Full refresh every N pages (0-10)", self.rcountmax, true)
+				"Full refresh every N pages (0-200)", self.rcountmax, true)
 			-- convert string to number
 			if pcall(function () count = math.floor(count) end) then
 				if count < 0 then
 					count = 0
-				elseif count > 10 then
-					count = 10
+				elseif count > 200 then
+					count = 200
 				end
 				self.rcountmax = count
 				-- storing this parameter in both global and local settings


### PR DESCRIPTION
On user @kaysin 's request increasing the maximum value for the number of pages before a full refresh to 200. I see no harm in doing so and clearly it has some use as there is someone who needs this.
