### PR TITLE
Set the header for Alt-M dialog

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -673,7 +673,7 @@ and/or dangerous functions able to crash the reader. ]]
 function FileChooser:changeFileChooserMode()
 	local face_list = { "Safe mode for beginners", "Advanced mode for experienced users", "Expert mode for beta-testers & developers" }
 	local modes_menu = SelectMenu:new{
-		menu_title = "Select proper mode to manage files",
+		menu_title = "Set user privilege level",
 		item_array = face_list,
 		current_entry = self.filemanager_expert_mode - 1,
 		}


### PR DESCRIPTION
I have changed the help for this (in PR #448), but forgot to change the actual header drawn at the top of this dialog.
