### PR TITLE
Delete the correct command group and use correct keys in crereader

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -625,6 +625,7 @@ function CREReader:adjustCreReaderCommands()
 		Keydef:new(KEY_FW_UP,MOD_ALT), Keydef:new(KEY_FW_DOWN,MOD_ALT)},
 		"Jump between bookmarks",
 		function(unireader,keydef)
+			local bm = nil
 			if keydef.keycode == KEY_FW_UP then
 				bm = self:prevBookMarkedPage()
 			else

--- a/crereader.lua
+++ b/crereader.lua
@@ -621,12 +621,12 @@ function CREReader:adjustCreReaderCommands()
 			end
 		end
 	)
-	self.commands:addGroup(MOD_ALT.."up/down",{
-		Keydef:new(KEY_FW_UP,MOD_ALT), Keydef:new(KEY_FW_DOWN,MOD_ALT)},
+	self.commands:addGroup(MOD_ALT.."K/L",{
+		Keydef:new(KEY_K,MOD_ALT), Keydef:new(KEY_L,MOD_ALT)},
 		"Jump between bookmarks",
 		function(unireader,keydef)
 			local bm = nil
-			if keydef.keycode == KEY_FW_UP then
+			if keydef.keycode == KEY_K then
 				bm = self:prevBookMarkedPage()
 			else
 				bm = self:nextBookMarkedPage()

--- a/crereader.lua
+++ b/crereader.lua
@@ -427,7 +427,7 @@ end
 
 function CREReader:adjustCreReaderCommands()
 	self.commands:delGroup("[joypad]")
-	self.commands:delGroup(MOD_ALT.."K/L")
+	self.commands:delGroup(MOD_ALT.."H/J")
 	self.commands:del(KEY_G, nil, "G")
 	self.commands:del(KEY_J, MOD_SHIFT, "J")
 	self.commands:del(KEY_K, MOD_SHIFT, "K")


### PR DESCRIPTION
1. By mistake I deleted the Alt-K/L (bookmark cycling) command group in crereader instead of Alt-H/J (TOC cycling) group.
2. When I switched unireader from using Alt-Up/Down to Alt-K/L I forgot to do the same for crereader.
