### PR TITLE
Bugfix: initialize show_overlap_enable flag

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -3,6 +3,7 @@ require "unireader"
 DJVUReader = UniReader:new{}
 
 function DJVUReader:setDefaults()
+	self.show_overlap_enable = true
 	self.show_links_enable = false
 end
 


### PR DESCRIPTION
We must initialize `show_overlap_enable` to `true` in `DJVUReader:setDefaults()` method, otherwise it will be uninitialized on the first open of a DjVu file (i.e. with no history file).
