### PR TITLE
Minor optimization of UniReader:drawOrCache()

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1067,9 +1067,9 @@ function UniReader:drawOrCache(no, preCache)
 	-- #3 goal: we render the full page
 	-- #4 goal: we render next page, too. (TODO)
 
-	local pg_w = G_width / ( self.doc:getPages() )
 	local page_indicator = function()
 		if Debug('page_indicator',no) then
+			local pg_w = G_width / ( self.doc:getPages() )
 			fb.bb:invertRect( pg_w*(no-1),0, pg_w,10)
 			fb:refresh(1,     pg_w*(no-1),0, pg_w,10)
 		end


### PR DESCRIPTION
Cut down one access to a global, one table dereference, one call to C level getPages() and one division on each call to `UniReader:drawOrCache()` function, i.e. on each page draw including panning.

I personally would prefer to get rid of `page_indicator()` altogether (and save 6 function calls + 3 conditional checks), but if @dpavlin thinks it is needed during debugging then at least we can shift the calculation of `pg_w` local variable inside `page_indicator()` function.
