### PR TITLE
Make the last menu item keyboard shortcut work

### DIFF
--- a/selectmenu.lua
+++ b/selectmenu.lua
@@ -22,8 +22,8 @@ SelectMenu = {
 
 	item_shortcuts = {
 		"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P",
-		"A", "S", "D", "F", "G", "H", "J", "K", "L", "/",
-		"Z", "X", "C", "V", "B", "N", "M", ".", "Sym", "Ent",
+		"A", "S", "D", "F", "G", "H", "J", "K", "L", "Sym",
+		"Z", "X", "C", "V", "B", "N", "M", ".", "/", "Ent",
 		},
 	last_shortcut = 0,
 


### PR DESCRIPTION
On Kindle 3 the last menu item's keyboard shortcut should be "Sym" and not "/" as there is no "/" key on Kindle 3 (but there is one on DXG). Tested to work on both Kindle 3 and Kindle DXG (and on emulator where "Sym" is the right Shift key).

This is the bugfix for the issue #464
