### PR TITLE
add page size limit in reading pdf/djvu files

### DIFF
--- a/k2pdfopt.h
+++ b/k2pdfopt.h
@@ -26,7 +26,8 @@
 #include <fitz/fitz-internal.h>
 #include <libdjvu/ddjvuapi.h>
 
-void k2pdfopt_mupdf_reflow(fz_context *ctx, fz_pixmap *pix, double rot_deg);
+void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx, \
+		double dpi, double gamma, double rot_deg);
 void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, \
 		ddjvu_render_mode_t mode, ddjvu_format_t *fmt, double dpi);
 void k2pdfopt_rfbmp_size(int *width, int *height);

--- a/pdf.c
+++ b/pdf.c
@@ -512,60 +512,18 @@ static int closePage(lua_State *L) {
 }
 
 static int reflowPage(lua_State *L) {
-	fz_context *ctx;
-	fz_device *dev;
-	fz_pixmap *pix;
-	fz_rect bounds,bounds2;
-	fz_matrix ctm;
-	fz_bbox bbox;
 
 	PdfPage *page = (PdfPage*) luaL_checkudata(L, 1, "pdfpage");
 	DrawContext *dc = (DrawContext*) luaL_checkudata(L, 2, "drawcontext");
 
 	double dpi = 250*(dc->zoom);
-	double dpp;
-	dpp = dpi / 72.;
-	pix = NULL;
-	fz_var(pix);
-	bounds = fz_bound_page(page->doc->xref, page->page);
-	ctm = fz_scale(dpp, dpp);
-	//    ctm=fz_concat(ctm,fz_rotate(rotation));
-	bounds2 = fz_transform_rect(ctm, bounds);
-	bbox = fz_round_rect(bounds2);
-	//    ctm=fz_translate(0,-page->mediabox.y1);
-	//    ctm=fz_concat(ctm,fz_scale(dpp,-dpp));
-	//    ctm=fz_concat(ctm,fz_rotate(page->rotate));
-	//    ctm=fz_concat(ctm,fz_rotate(0));
-	//    bbox=fz_round_rect(fz_transform_rect(ctm,page->mediabox));
-	//    pix=fz_new_pixmap_with_rect(colorspace,bbox);
-	pix = fz_new_pixmap_with_bbox(page->doc->context, fz_device_gray, bbox);
-	printf("bbox:%d,%d,%d,%d\n",bbox.x0,bbox.y0,bbox.x1,bbox.y1);
-	fz_clear_pixmap_with_value(page->doc->context, pix, 0xff);
-	dev = fz_new_draw_device(page->doc->context, pix);
-#ifdef MUPDF_TRACE
-	fz_device *tdev;
-	fz_try(page->doc->context) {
-		tdev = fz_new_trace_device(page->doc->context);
-		fz_run_page(page->doc->xref, page->page, tdev, ctm, NULL);
-	}
-	fz_always(page->doc->context) {
-		fz_free_device(tdev);
-	}
-#endif
-	fz_run_page(page->doc->xref, page->page, dev, ctm, NULL);
-	fz_free_device(dev);
 
-	if(dc->gamma >= 0.0) {
-		fz_gamma_pixmap(page->doc->context, pix, dc->gamma);
-	}
 	int width, height;
-	k2pdfopt_mupdf_reflow(page->doc->context, pix, 0);
+	k2pdfopt_mupdf_reflow(page->doc->xref, page->page, page->doc->context, dpi, dc->gamma, 0);
 	k2pdfopt_rfbmp_size(&width, &height);
 
 	lua_pushnumber(L, (double)width);
 	lua_pushnumber(L, (double)height);
-
-	fz_drop_pixmap(page->doc->context, pix);
 
 	return 2;
 }


### PR DESCRIPTION
Occasionally koptreader will crash the KPV when reading a particularly large page in PDF/DJVU file. In this patch the maximum page size is set to 3000 x 4000, that is allocating no more than 12MB memory in reading one page. In most cases, this page size should be enough. In the future the maximum page size could be user configurable.
