### PR TITLE
LuaJIT: make distclean -> make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ clean:
 	rm -f *.o kpdfview slider_watcher
 
 cleanthirdparty:
-	$(MAKE) -C $(LUADIR) CC="$(HOSTCC)" CFLAGS="$(BASE_CFLAGS)" distclean
+	$(MAKE) -C $(LUADIR) CC="$(HOSTCC)" CFLAGS="$(BASE_CFLAGS)" clean
 	$(MAKE) -C $(MUPDFDIR) build="release" clean
 	$(MAKE) -C $(CRENGINEDIR)/thirdparty/antiword clean
 	test -d $(CRENGINEDIR)/thirdparty/chmlib && $(MAKE) -C $(CRENGINEDIR)/thirdparty/chmlib clean || echo warn: chmlib folder not found


### PR DESCRIPTION
Two reasons for this change:
1. The latest LuaJIT has no "distclean" target, so we'll have to change anyway when we upgrade to it (hopefully, soon)
2. The `make distclean` is MUCH slower than `make clean`.
