### PR TITLE
remove unused variable reflow_mode_enable in pagehash

### DIFF
--- a/koptreader.lua
+++ b/koptreader.lua
@@ -65,7 +65,7 @@ function KOPTReader:drawOrCache(no, preCache)
 	local dc = self:setzoom(page, preCache)
 	
 	-- check if we have relevant cache contents
-	local pagehash = no..'_'..(self.reflow_mode_enable and 1 or 0)..'_'..self.globalzoom..'_'..self.globalrotate..'_'..self.globalgamma
+	local pagehash = no..'_'..self.globalzoom..'_'..self.globalrotate..'_'..self.globalgamma
 	Debug('page hash', pagehash)
 	if self.cache[pagehash] ~= nil then
 		-- we have something in cache


### PR DESCRIPTION
There is no such variable as reflow_mode_enable but why the Lua interpreter just run this line as happy as there were? Is this a language feature?
