### PR TITLE
Bugfix: support opening the specified file again

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -154,8 +154,8 @@ local patharg = G_reader_settings:readSetting("lastfile")
 if ARGV[argidx] and lfs.attributes(ARGV[argidx], "mode") == "directory" then
 	FileChooser:setPath(ARGV[argidx])
 	FileChooser:choose(0, G_height)
-elseif ARGV[optind] and lfs.attributes(ARGV[optind], "mode") == "file" then
-	openFile(ARGV[optind], optarg["p"])
+elseif ARGV[argidx] and lfs.attributes(ARGV[argidx], "mode") == "file" then
+	openFile(ARGV[argidx])
 elseif patharg and lfs.attributes(patharg, "mode") == "file" then
 	openFile(patharg)
 else


### PR DESCRIPTION
My cleanup change broke the case of "reader.lua -d file.pdf". Fixed now.
