### PR TITLE
Use only Back not Home to exit dialogs

### DIFF
--- a/inputbox.lua
+++ b/inputbox.lua
@@ -475,7 +475,7 @@ function InputBox:addAllCommands()
 	-- NuPogodi, 02.06.12: inputmode-dependent commands are collected
 	self:ModeDependentCommands() -- here
 
-	self.commands:add({KEY_BACK, KEY_HOME}, nil, "Back, Home",
+	self.commands:add(KEY_BACK, nil, "Back",
 		"back",
 		function(self)
 			self.input_string = nil

--- a/selectmenu.lua
+++ b/selectmenu.lua
@@ -238,7 +238,7 @@ function SelectMenu:addAllCommands()
 		HelpPage:show(0, G_height, sm.commands)
 		sm.pagedirty = true
 	end)
-	self.commands:add({KEY_BACK,KEY_HOME}, nil, "Back, Home",
+	self.commands:add(KEY_BACK, nil, "Back",
 		"exit menu",
 		function(sm)
 			return "break"
@@ -249,7 +249,7 @@ end
 function SelectMenu:clearCommands()
 	self.commands = Commands:new{}
 
-	self.commands:add({KEY_BACK,KEY_HOME}, nil, "Back, Home",
+	self.commands:add(KEY_BACK, nil, "Back",
 		"exit menu",
 		function(sm)
 			return "break"

--- a/unireader.lua
+++ b/unireader.lua
@@ -2795,7 +2795,7 @@ function UniReader:addAllCommands()
 						factor = ev.code - KEY_Z + 20
 						x_direction = last_direction["x"]
 						y_direction = last_direction["y"]
-					elseif ev.code == KEY_BACK or ev.code == KEY_HOME then
+					elseif ev.code == KEY_BACK then
 						running_corner = false
 					end
 


### PR DESCRIPTION
It is not a good idea to use the key that exits the whole application for exiting a dialog, because accidentally pressing that key twice will exit the application and annoy the user.
