### PR TITLE
Extract attachments from PDF file via Alt-S

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ LUALIB := $(LUADIR)/src/libluajit.a
 
 POPENNSLIB := $(POPENNSDIR)/libpopen_noshell.a
 
-all: kpdfview
+all: kpdfview extr
 
 VERSION?=$(shell git describe HEAD)
 kpdfview: kpdfview.o einkfb.o pdf.o k2pdfopt.o blitbuffer.o drawcontext.o input.o $(POPENNSLIB) util.o ft.o lfs.o mupdfimg.o $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) djvu.o $(DJVULIBS) cre.o $(CRENGINELIBS) pic.o pic_jpeg.o
@@ -143,6 +143,12 @@ kpdfview: kpdfview.o einkfb.o pdf.o k2pdfopt.o blitbuffer.o drawcontext.o input.
 		-lm -ldl -lpthread -ljpeg -L$(MUPDFLIBDIR) \
 		$(EMU_LDFLAGS) \
 		$(DYNAMICLIBSTDCPP)
+
+extr:	extr.o
+	$(CC) $(CFLAGS) extr.o $(MUPDFLIBS) $(THIRDPARTYLIBS) -lm -o extr
+
+extr.o:	%.o: %.c
+	$(CC) -c -I$(MUPDFDIR)/pdf -I$(MUPDFDIR)/fitz $< -o $@
 
 slider_watcher.o: %.o: %.c
 	$(CC) -c $(CFLAGS) $< -o $@
@@ -203,7 +209,7 @@ fetchthirdparty:
 	cd popen-noshell && test -f Makefile || patch -N -p0 < popen_noshell-buildfix.patch
 
 clean:
-	rm -f *.o kpdfview slider_watcher
+	rm -f *.o kpdfview slider_watcher extr
 
 cleanthirdparty:
 	$(MAKE) -C $(LUADIR) CC="$(HOSTCC)" CFLAGS="$(BASE_CFLAGS)" clean
@@ -264,13 +270,14 @@ INSTALL_DIR=kindlepdfviewer
 LUA_FILES=commands.lua crereader.lua dialog.lua djvureader.lua readerchooser.lua filechooser.lua filehistory.lua fileinfo.lua filesearcher.lua font.lua graphics.lua helppage.lua image.lua inputbox.lua keys.lua pdfreader.lua koptreader.lua picviewer.lua reader.lua rendertext.lua screen.lua selectmenu.lua settings.lua unireader.lua widget.lua
 
 customupdate: all
-	# ensure that build binary is for ARM
+	# ensure that the binaries were built for ARM
 	file kpdfview | grep ARM || exit 1
-	$(STRIP) --strip-unneeded kpdfview
+	file extr | grep ARM || exit 1
+	$(STRIP) --strip-unneeded kpdfview extr
 	rm -f kindlepdfviewer-$(VERSION).zip
 	rm -rf $(INSTALL_DIR)
 	mkdir -p $(INSTALL_DIR)/{history,screenshots}
-	cp -p README.md COPYING kpdfview kpdf.sh $(LUA_FILES) $(INSTALL_DIR)
+	cp -p README.md COPYING kpdfview extr kpdf.sh $(LUA_FILES) $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/data
 	cp -rpL data/*.css $(INSTALL_DIR)/data
 	cp -rpL fonts $(INSTALL_DIR)

--- a/extr.c
+++ b/extr.c
@@ -25,7 +25,6 @@
 #include "mupdf-internal.h"
 #include <libgen.h>
 
-/* doc is shared between save_attachments() and dump_stream() */
 static pdf_document *doc;
 
 void dump_stream(int i, FILE *fout)

--- a/extr.c
+++ b/extr.c
@@ -1,25 +1,25 @@
 /*
-    extr: Extract attachments from PDF file
+	extr: Extract attachments from PDF file
 
 	Usage: extr /dir/file.pdf pageno
 	Returns 0 if one or more attachments saved, otherwise returns non-zero.
 	Prints the number of saved attachments on stdout.
 	Attachments are saved in /dir directory with the appropriate filenames.
 
-    Copyright (C) 2012 Tigran Aivazian <tigran@bibles.org.uk>
+	Copyright (C) 2012 Tigran Aivazian <tigran@bibles.org.uk>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "mupdf-internal.h"

--- a/extr.c
+++ b/extr.c
@@ -50,7 +50,7 @@ int save_attachments(int pageno, char *targetdir)
 		pdf_obj *fs_obj = pdf_dict_gets(annot->obj, "FS");
 		if (fs_obj) {
 			pdf_obj *ef_obj;
-			char *name = pdf_to_str_buf(pdf_dict_gets(fs_obj, "F"));
+			char *name = basename(strdup(pdf_to_str_buf(pdf_dict_gets(fs_obj, "F"))));
 			ef_obj = pdf_dict_gets(fs_obj, "EF");
 			if (ef_obj) {
 				pdf_obj *f_obj = pdf_dict_gets(ef_obj, "F");

--- a/extr.c
+++ b/extr.c
@@ -1,0 +1,106 @@
+/*
+    extr: Extract attachments from PDF file
+
+	Usage: extr /dir/file.pdf pageno
+	Returns 0 if one or more attachments saved, otherwise returns non-zero.
+	Prints the number of saved attachments on stdout.
+	Attachments are saved in /dir directory with the appropriate filenames.
+
+    Copyright (C) 2012 Tigran Aivazian <tigran@bibles.org.uk>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "mupdf-internal.h"
+#include <libgen.h>
+
+/* doc is shared between save_attachments() and dump_stream() */
+static pdf_document *doc;
+
+void dump_stream(int i, FILE *fout)
+{
+	fz_stream *stm = pdf_open_stream(doc, i, 0);
+	static unsigned char buf[8192];
+	while (1) {
+		int n = fz_read(stm, buf, sizeof buf);
+		if (n == 0) break;
+		fwrite(buf, 1, n, fout);
+	}
+	fz_close(stm);
+}
+
+/* returns the number of attachments saved */
+int save_attachments(int pageno, char *targetdir)
+{
+	pdf_page *page = pdf_load_page(doc, pageno-1);
+	pdf_annot *annot;
+	int saved_count = 0;
+
+	for (annot = page->annots; annot ; annot = annot->next) {
+		pdf_obj *fs_obj = pdf_dict_gets(annot->obj, "FS");
+		if (fs_obj) {
+			pdf_obj *ef_obj;
+			char *name = pdf_to_str_buf(pdf_dict_gets(fs_obj, "F"));
+			ef_obj = pdf_dict_gets(fs_obj, "EF");
+			if (ef_obj) {
+				pdf_obj *f_obj = pdf_dict_gets(ef_obj, "F");
+				if (f_obj && pdf_is_indirect(f_obj)) {
+					static char pathname[PATH_MAX];
+					sprintf(pathname, "%s/%s", targetdir, name);
+					FILE *fout = fopen(pathname, "w");
+					if (!fout) {
+						fprintf(stderr, "extr: cannot write to file %s\n", name);
+						exit(1);
+					}
+					dump_stream(pdf_to_num(f_obj), fout);
+					fclose(fout);
+					saved_count++;
+				}
+			}
+		}
+	}
+	return saved_count;
+}
+
+int main(int argc, char *argv[])
+{
+	int saved = 0;
+
+	if (argc != 3) {
+		printf("Usage: extr file.pdf pageno\n");
+		exit(1);
+	}
+
+	char *filename = strdup(argv[1]);
+	char *dir = dirname(strdup(filename));
+	int pageno = atoi(argv[2]);
+
+	fz_context *ctx = fz_new_context(NULL, NULL, FZ_STORE_UNLIMITED);
+	if (!ctx) {
+		fprintf(stderr, "extr: cannot create context\n");
+		exit(1);
+	}
+
+	fz_var(doc);
+	fz_try(ctx) {
+		doc = pdf_open_document(ctx, filename);
+		saved = save_attachments(pageno, dir);
+	}
+	fz_catch(ctx)
+	{
+	}
+
+	printf("%d\n", saved);
+	return 0;
+}

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -294,9 +294,10 @@ end
 function FileChooser:addAllCommands()
 	self.commands = Commands:new{}
 
-	self.commands:add({KEY_SPACE}, nil, "Space",
-		"refresh page manually",
+	self.commands:add(KEY_SPACE, nil, "Space",
+		"refresh file list",
 		function(self)
+			self:setPath(self.path)
 			self.pagedirty = true
 		end
 	)

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -52,7 +52,7 @@ function getUnpackedZipSize(zipfile)
 	-- adding quotes allows us to avoid crash on zips which filename contains space(s)
 	local cmd='unzip -l \"'..zipfile..'\" | tail -1 | sed -e "s/^ *\\([0-9][0-9]*\\) *.*/\\1/"'
 	local p = io.popen(cmd, "r")
-	local res = assert(p:read("*a"))
+	local res = p:read("*a")
 	p:close()
 	res = string.gsub(res, "[\n\r]+", "")
 	return tonumber(res)

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -40,6 +40,7 @@ fi
 
 declare outfile=""
 declare -a infiles=()
+declare -a infiles_texclean=()
 declare -a infilesize=()
 declare -i infcount=0 outfcount=0 totalsize=0
 
@@ -71,6 +72,7 @@ do
 		usage
 	fi
 	infiles[$infcount]="$fullname"
+	infiles_texclean[$infcount]=$(escape_tex_specialchars $(basename "${infiles[$infcount]}"))
 	infilesize[$infcount]=$(stat --print="%s" "$fullname")
 	((totalsize=totalsize+${infilesize[$infcount]}))
 	((infcount++))
@@ -90,18 +92,26 @@ fi
 workdir=$(mktemp --tmpdir -d pdfattach.XXXXXX)
 cd $workdir
 > tmp.tex
+# emit TeX preamble
 echo -E "\documentclass{book}" >> tmp.tex
 echo -E "\usepackage[margin={1mm},papersize={9cm,12cm}]{geometry}" >> tmp.tex
-echo -E "\usepackage{attachfile}" >> tmp.tex
+echo -E "\usepackage{hyperref,attachfile}" >> tmp.tex
 echo -E "\begin{document}" >> tmp.tex
-echo -E "\pagestyle{empty}\small" >> tmp.tex
+echo -E "\tolerance=10000\pagestyle{empty}\fontsize{7}{13}\selectfont" >> tmp.tex
+
+# emit the list of all files
 for ((i = 0 ; i < ${#infiles[*]} ; i++));
 do
-	descr=$(escape_tex_specialchars $(basename "${infiles[$i]}"))
-	echo -E "\noindent $((i+1)): $descr (\textattachfile[color={0 0 0}]{${infiles[$i]}}{${infilesize[$i]} bytes})" >> tmp.tex
+	echo -E "\noindent \hyperlink{L$i}{$((i+1))/${infcount}} \texttt{${infiles_texclean[$i]}} (${infilesize[$i]} bytes)" >> tmp.tex
 	echo >> tmp.tex
 done
-echo -E "\noindent Total size $totalsize bytes" >> tmp.tex
+echo -E "\noindent Total size $totalsize bytes\newpage" >> tmp.tex
+
+# now emit all the attachments, one per page
+for ((i = 0 ; i < ${#infiles[*]} ; i++));
+do
+	echo -E "\noindent\hypertarget{L$i}$((i+1))/${infcount}\\\\\texttt{${infiles_texclean[$i]}} (\textattachfile[color={0 0 0}]{${infiles[$i]}}{${infilesize[$i]} bytes})\newpage" >> tmp.tex
+done
 echo -E "\end{document}" >> tmp.tex
 pdflatex -halt-on-error tmp.tex > /dev/null && mv tmp.pdf "$outfile"
 cd - > /dev/null

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -12,30 +12,34 @@ progname=$(basename $0)
 
 function usage()
 {
-	echo "Usage: $progname -o file.pdf -i file1.djvu [-i file2.mp3] ..."
+	echo "Usage: $progname -o file.pdf file1.djvu [file2.mp3] ..."
 	exit 1
 }
 
-if (! getopts ":o:i:" opt); then
+if (! getopts ":o:" opt); then
 	echo "$progname: Missing options." >&2
 	usage
+fi
+
+if ! type pdflatex > /dev/null 2>&1 ; then
+	echo "$progname: pdfLaTeX program is required." >&2
+	exit 1
+fi
+
+if ! kpsewhich attachfile.sty > /dev/null 2>&1 ; then
+	echo "$progname: attachfile.sty package is required." >&2
+	exit 1
 fi
 
 declare outfile=""
 declare -a infiles=()
 declare -i infcount=0 outfcount=0
 
-while getopts ":i:o:" opt; do
+while getopts ":o:" opt; do
 	case $opt in
 	o)
-		outfile="$OPTARG"
-		outbase=$(basename $outfile | cut -d'.' -f1)
-		targetdir=$(dirname $outfile)
+		outfile=$(readlink -f "$OPTARG")
 		((outfcount++))
-		;;
-	i)
-		infiles[$infcount]=$(readlink -f "$OPTARG")
-		((infcount++))
 		;;
 	\?)
 		echo "$progname: Invalid option: -$OPTARG" >&2
@@ -48,6 +52,21 @@ while getopts ":i:o:" opt; do
 	esac
 done
 
+shift $((OPTIND-1))
+
+numargs=$#
+for ((i=1 ; i <= $numargs ; i++))
+do
+	fullname=$(readlink -f "$1")
+	if [ ! -f "$fullname" ] ; then
+		echo "$progname: file \"$fullname\" does not exist" >&2
+		usage
+	fi
+	infiles[$infcount]="$fullname"
+	((infcount++))
+	shift
+done
+
 if ((infcount == 0)) ; then
 	echo "$progname: No input file(s) specified." >&2
 	usage
@@ -58,19 +77,18 @@ if ((outfcount != 1)) ; then
 	usage
 fi
 
-
 workdir=$(mktemp --tmpdir -d pdfattach.XXXXXX)
 cd $workdir
-> ${outbase}.tex
-echo -E "\documentclass{book}" >> ${outbase}.tex
-echo -E "\usepackage{attachfile}" >> ${outbase}.tex
-echo -E "\begin{document}" >> ${outbase}.tex
-echo -E "\pagestyle{empty}" >> ${outbase}.tex
+> tmp.tex
+echo -E "\documentclass{book}" >> tmp.tex
+echo -E "\usepackage{attachfile}" >> tmp.tex
+echo -E "\begin{document}" >> tmp.tex
+echo -E "\pagestyle{empty}" >> tmp.tex
 for ((i = 0 ; i < ${#infiles[*]} ; i++));
 do
-	echo "\attachfile{${infiles[$i]}}" >> ${outbase}.tex
+	echo "\attachfile{${infiles[$i]}}" >> tmp.tex
 done
-echo -E "\end{document}" >> ${outbase}.tex
-pdflatex -halt-on-error ${outbase} > /dev/null && mv ${outbase}.pdf $targetdir
+echo -E "\end{document}" >> tmp.tex
+pdflatex -halt-on-error tmp.tex > /dev/null && mv tmp.pdf "$outfile"
 cd - > /dev/null
 rm -rf $workdir

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+#
+# pdfattach --- embed specified file(s) in a specified PDF file
+# Requires pdfLaTeX and attachfile.sty package to run
+# Returns 0 on success or >0 on error
+#
+# Written by Tigran Aivazian <tigran@bibles.org.uk>
+#
+
+progname=$(basename $0)
+
+function usage()
+{
+	echo "Usage: $progname -o file.pdf -i file1.djvu [-i file2.mp3] ..."
+	exit 1
+}
+
+if (! getopts ":o:i:" opt); then
+	echo "$progname: Missing options." >&2
+	usage
+fi
+
+declare outfile=""
+declare -a infiles=()
+declare -i infcount=0 outfcount=0
+
+while getopts ":i:o:" opt; do
+	case $opt in
+	o)
+		outfile="$OPTARG"
+		outbase=$(basename $outfile | cut -d'.' -f1)
+		targetdir=$(dirname $outfile)
+		((outfcount++))
+		;;
+	i)
+		infiles[$infcount]=$(readlink -f "$OPTARG")
+		((infcount++))
+		;;
+	\?)
+		echo "$progname: Invalid option: -$OPTARG" >&2
+		usage
+		;;
+	:)
+		echo "$progname: Option -$OPTARG requires an argument." >&2
+		usage
+		;;
+	esac
+done
+
+if ((infcount == 0)) ; then
+	echo "$progname: No input file(s) specified." >&2
+	usage
+fi
+
+if ((outfcount != 1)) ; then
+	echo "$progname: One (and only one) output file must be specified." >&2
+	usage
+fi
+
+
+workdir=$(mktemp --tmpdir -d pdfattach.XXXXXX)
+cd $workdir
+> ${outbase}.tex
+echo -E "\documentclass{book}" >> ${outbase}.tex
+echo -E "\usepackage{attachfile}" >> ${outbase}.tex
+echo -E "\begin{document}" >> ${outbase}.tex
+echo -E "\pagestyle{empty}" >> ${outbase}.tex
+for ((i = 0 ; i < ${#infiles[*]} ; i++));
+do
+	echo "\attachfile{${infiles[$i]}}" >> ${outbase}.tex
+done
+echo -E "\end{document}" >> ${outbase}.tex
+pdflatex -halt-on-error ${outbase} > /dev/null && mv ${outbase}.pdf $targetdir
+cd - > /dev/null
+rm -rf $workdir

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -10,6 +10,13 @@
 
 progname=$(basename $0)
 
+function escape_tex_specialchars()
+{
+	local txt=$1
+	local res=$(echo "$txt" | sed -e "s%_%\\\_%g")
+	echo "$res"
+}
+
 function usage()
 {
 	echo "Usage: $progname -o file.pdf file1.djvu [file2.mp3] ..."
@@ -33,7 +40,8 @@ fi
 
 declare outfile=""
 declare -a infiles=()
-declare -i infcount=0 outfcount=0
+declare -a infilesize=()
+declare -i infcount=0 outfcount=0 totalsize=0
 
 while getopts ":o:" opt; do
 	case $opt in
@@ -63,6 +71,8 @@ do
 		usage
 	fi
 	infiles[$infcount]="$fullname"
+	infilesize[$infcount]=$(stat --print="%s" "$fullname")
+	((totalsize=totalsize+${infilesize[$infcount]}))
 	((infcount++))
 	shift
 done
@@ -81,13 +91,17 @@ workdir=$(mktemp --tmpdir -d pdfattach.XXXXXX)
 cd $workdir
 > tmp.tex
 echo -E "\documentclass{book}" >> tmp.tex
+echo -E "\usepackage[margin={1mm},papersize={9cm,12cm}]{geometry}" >> tmp.tex
 echo -E "\usepackage{attachfile}" >> tmp.tex
 echo -E "\begin{document}" >> tmp.tex
-echo -E "\pagestyle{empty}" >> tmp.tex
+echo -E "\pagestyle{empty}\small" >> tmp.tex
 for ((i = 0 ; i < ${#infiles[*]} ; i++));
 do
-	echo "\attachfile{${infiles[$i]}}" >> tmp.tex
+	descr=$(escape_tex_specialchars $(basename "${infiles[$i]}"))
+	echo -E "\noindent $((i+1)): $descr (\textattachfile[color={0 0 0}]{${infiles[$i]}}{${infilesize[$i]} bytes})" >> tmp.tex
+	echo >> tmp.tex
 done
+echo -E "\noindent Total size $totalsize bytes" >> tmp.tex
 echo -E "\end{document}" >> tmp.tex
 pdflatex -halt-on-error tmp.tex > /dev/null && mv tmp.pdf "$outfile"
 cd - > /dev/null

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -13,7 +13,7 @@ progname=$(basename $0)
 function escape_tex_specialchars()
 {
 	local txt=$1
-	local res=$(echo "$txt" | sed -e "s%_%\\\_%g")
+	local res=$(echo "$txt" | sed -e "s%_%\\\_%g" -e "s%&%\\\&%g")
 	echo "$res"
 }
 


### PR DESCRIPTION
This PR contains the following commits:
1. Makes file info function more resilient, i.e. we shouldn't crash the whole KPV application just because we cannot discover the correct unpacked size of a zip file. This commit is unrelated to the main theme of this PR, so I sin against my own advocated rule, but this particular commit is trivial enough to be forgiven, I dare hope :)
2. The Space command in FileChooser should actually re-read the directory and not just redraw the current (possibly stale) data. This is especially useful in two situations: a) You have extracted some attachments in the current directory b) You wish to see the current state of the Last Documents list. The reason the Alt-S command does not do this automatically is because the file may have been opened via "open last file" (Shift-P-P) command and then the FileChooser object may not even exist.
3. Adds Alt-S command to PDFReader which invokes the external utility "extr" passing it the full pathname of the open PDF file and the current page number. The utility extracts all attachments on this page (if there are any) and saves them in the same directory as the PDF file. The file names given to attachments are decoded from within the PDF file itself, i.e. they are the same as the original file names of the files embedded in the PDF.

While you are reviewing this PR I'll write a little shell script which generates a PDF file with the given files embedded into it as attachments, as promised.
