### PR TITLE
bugfix: isolate doc settings of koptreader from pdfreader/djvureader and feedback zoom value used by page reflow

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -476,16 +476,16 @@ static int reflowPage(lua_State *L) {
 	DrawContext *dc = (DrawContext*) luaL_checkudata(L, 2, "drawcontext");
 	ddjvu_render_mode_t mode = (int) luaL_checkint(L, 3);
 
-	double dpi = 250*(dc->zoom);
-
 	int width, height;
-	k2pdfopt_djvu_reflow(page->page_ref, page->doc->context, mode, page->doc->pixelformat, dpi);
+	k2pdfopt_djvu_reflow(page->page_ref, page->doc->context, mode, page->doc->pixelformat, dc->zoom);
 	k2pdfopt_rfbmp_size(&width, &height);
+	k2pdfopt_rfbmp_zoom(&dc->zoom);
 
 	lua_pushnumber(L, (double)width);
 	lua_pushnumber(L, (double)height);
+	lua_pushnumber(L, (double)dc->zoom);
 
-	return 2;
+	return 3;
 }
 
 static int drawReflowedPage(lua_State *L) {

--- a/k2pdfopt.c
+++ b/k2pdfopt.c
@@ -218,7 +218,7 @@ static double dst_min_figure_height_in = 0.75;
 static int dst_fulljustify = -1; // 0 = no, 1 = yes
 static int dst_color = 0;
 static int dst_landscape = 0;
-static double dst_mar = 0.02;
+static double dst_mar = 0.06;
 static double dst_martop = -1.0;
 static double dst_marbot = -1.0;
 static double dst_marleft = -1.0;
@@ -491,10 +491,10 @@ void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx, \
 		//    ctm=fz_concat(ctm,fz_rotate(rotation));
 		bounds2 = fz_transform_rect(ctm, bounds);
 		bbox = fz_round_rect(bounds2);
-		printf("reading page:%d,%d,%d,%d dpi:%.0f\n",bbox.x0,bbox.y0,bbox.x1,bbox.y1,dpi);
+		printf("reading page:%d,%d,%d,%d zoom:%.2f dpi:%.0f\n",bbox.x0,bbox.y0,bbox.x1,bbox.y1,zoom,dpi);
 		zoom_value = zoom;
 		zoom *= shrink_factor;
-		dpi *= zoom;
+		dpi *= shrink_factor;
 	} while (bbox.x1 > max_page_width_pix | bbox.y1 > max_page_height_pix);
 	//    ctm=fz_translate(0,-page->mediabox.y1);
 	//    ctm=fz_concat(ctm,fz_scale(dpp,-dpp));
@@ -553,7 +553,7 @@ void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, \
 		printf("reading page:%d,%d,%d,%d dpi:%.0f\n",prect.x,prect.y,prect.w,prect.h,dpi);
 		zoom_value = zoom;
 		zoom *= shrink_factor;
-		dpi *= zoom;
+		dpi *= shrink_factor;
 	} while (prect.w > max_page_width_pix | prect.h > max_page_height_pix);
 	rrect = prect;
 

--- a/k2pdfopt.c
+++ b/k2pdfopt.c
@@ -409,6 +409,7 @@ static int master_bmp_height = 0;
 static int max_page_width_pix = 3000;
 static int max_page_height_pix = 4000;
 static double shrink_factor = 0.9;
+static double zoom_value = 1.0;
 
 static void k2pdfopt_reflow_bmp(MASTERINFO *masterinfo, WILLUSBITMAP *src) {
 	PAGEINFO _pageinfo, *pageinfo;
@@ -471,7 +472,7 @@ static void k2pdfopt_reflow_bmp(MASTERINFO *masterinfo, WILLUSBITMAP *src) {
 }
 
 void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx, \
-		double dpi, double gamma, double rot_deg) {
+		double zoom, double gamma, double rot_deg) {
 	fz_device *dev;
 	fz_pixmap *pix;
 	fz_rect bounds,bounds2;
@@ -480,6 +481,7 @@ void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx, \
 	WILLUSBITMAP _src, *src;
 
 	double dpp;
+	double dpi = 250*zoom;
 	do {
 		dpp = dpi / 72.;
 		pix = NULL;
@@ -490,7 +492,9 @@ void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx, \
 		bounds2 = fz_transform_rect(ctm, bounds);
 		bbox = fz_round_rect(bounds2);
 		printf("reading page:%d,%d,%d,%d dpi:%.0f\n",bbox.x0,bbox.y0,bbox.x1,bbox.y1,dpi);
-		dpi = dpi*shrink_factor;
+		zoom_value = zoom;
+		zoom *= shrink_factor;
+		dpi *= zoom;
 	} while (bbox.x1 > max_page_width_pix | bbox.y1 > max_page_height_pix);
 	//    ctm=fz_translate(0,-page->mediabox.y1);
 	//    ctm=fz_concat(ctm,fz_scale(dpp,-dpp));
@@ -529,11 +533,12 @@ void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx, \
 }
 
 void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, \
-		ddjvu_render_mode_t mode, ddjvu_format_t *fmt, double dpi) {
+		ddjvu_render_mode_t mode, ddjvu_format_t *fmt, double zoom) {
 	WILLUSBITMAP _src, *src;
 	ddjvu_rect_t prect;
 	ddjvu_rect_t rrect;
 	int i, iw, ih, idpi, status;
+	double dpi = 250*zoom;
 
 	while (!ddjvu_page_decoding_done(page))
 			handle(1, ctx);
@@ -546,7 +551,9 @@ void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, \
 		prect.w = iw * dpi / idpi;
 		prect.h = ih * dpi / idpi;
 		printf("reading page:%d,%d,%d,%d dpi:%.0f\n",prect.x,prect.y,prect.w,prect.h,dpi);
-		dpi = dpi*shrink_factor;
+		zoom_value = zoom;
+		zoom *= shrink_factor;
+		dpi *= zoom;
 	} while (prect.w > max_page_width_pix | prect.h > max_page_height_pix);
 	rrect = prect;
 
@@ -581,6 +588,10 @@ void k2pdfopt_rfbmp_size(int *width, int *height) {
 
 void k2pdfopt_rfbmp_ptr(unsigned char** bmp_ptr_ptr) {
 	*bmp_ptr_ptr = masterinfo->bmp.data;
+}
+
+void k2pdfopt_rfbmp_zoom(double *zoom) {
+	*zoom = zoom_value;
 }
 
 /* ansi.c */

--- a/k2pdfopt.h
+++ b/k2pdfopt.h
@@ -32,6 +32,7 @@ void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, \
 		ddjvu_render_mode_t mode, ddjvu_format_t *fmt, double dpi);
 void k2pdfopt_rfbmp_size(int *width, int *height);
 void k2pdfopt_rfbmp_ptr(unsigned char** bmp_ptr_ptr);
+void k2pdfopt_rfbmp_zoom(double *zoom);
 
 #endif
 

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -123,7 +123,8 @@ function KOPTReader:drawOrCache(no, preCache)
 	end
 	
 	self.fullwidth, self.fullheight, self.kopt_zoom = page:reflow(dc, self.render_mode)
-	Debug("page::reflowPage:", "width:", self.fullwidth, "height:", self.fullheight)
+	self.globalzoom_orig = self.kopt_zoom
+	Debug("page::reflowPage:", "width:", self.fullwidth, "height:", self.fullheight, "zoom:", self.kopt_zoom)
 	
 	if (self.fullwidth * self.fullheight / 2) <= max_cache then
 		-- yes we can, so do this with offset 0, 0
@@ -193,7 +194,7 @@ function KOPTReader:setzoom(page, preCache)
 	end
 	
 	dc:setZoom(self.kopt_zoom)
-	self.globalzoom_orig = self.kopt_zoom
+	Debug("setzoom:", "globalzoom_orig", self.globalzoom_orig)
 	
 	if self.kopt_gamma ~= self.GAMMA_NO_GAMMA then
 		Debug("gamma correction: ", self.kopt_gamma)

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -122,7 +122,7 @@ function KOPTReader:drawOrCache(no, preCache)
 		max_cache = max_cache - self.cache[self.pagehash].size
 	end
 	
-	self.fullwidth, self.fullheight = page:reflow(dc, self.render_mode)
+	self.fullwidth, self.fullheight, self.kopt_zoom = page:reflow(dc, self.render_mode)
 	Debug("page::reflowPage:", "width:", self.fullwidth, "height:", self.fullheight)
 	
 	if (self.fullwidth * self.fullheight / 2) <= max_cache then

--- a/pdf.c
+++ b/pdf.c
@@ -516,16 +516,16 @@ static int reflowPage(lua_State *L) {
 	PdfPage *page = (PdfPage*) luaL_checkudata(L, 1, "pdfpage");
 	DrawContext *dc = (DrawContext*) luaL_checkudata(L, 2, "drawcontext");
 
-	double dpi = 250*(dc->zoom);
-
 	int width, height;
-	k2pdfopt_mupdf_reflow(page->doc->xref, page->page, page->doc->context, dpi, dc->gamma, 0);
+	k2pdfopt_mupdf_reflow(page->doc->xref, page->page, page->doc->context, dc->zoom, dc->gamma, 0);
 	k2pdfopt_rfbmp_size(&width, &height);
+	k2pdfopt_rfbmp_zoom(&dc->zoom);
 
 	lua_pushnumber(L, (double)width);
 	lua_pushnumber(L, (double)height);
+	lua_pushnumber(L, (double)dc->zoom);
 
-	return 2;
+	return 3;
 }
 
 static int drawReflowedPage(lua_State *L) {


### PR DESCRIPTION
`koptreader` interprets `self.globalzoom` differently from `pdfreader`/`djvureader`.So change the variable in one reader will have unexpected effect in another. I isolated the variable `self.globalzoom` in `koptreader` and use another variable `self.kopt_zoom` so that when switching between `koptreader` and `pdfreader`/`djvureader` zoom values are stored independently in doc settings. I also introduced a new variable `self.kopt_gamma` which will have different visual effect from `self.gamma` in the future. Because modifying gamma costs very much in `koptreader` (full page will be re-reflowed) I used a different modification algorithm multiplying the original gamma with square of factor. So the changing step will be bigger.

Updates: in commit 564f73d `reflow` function will return zoom value used in K2pdfopt. Then `self.kopt_zoom` is set with the returned zoom value so that when zoom value exceeds the upper limit of reflowable page size user will notice that zoom value cannot be increased.
