### PR TITLE
Cleanups to extr.c and pdfattach

### DIFF
--- a/extr.c
+++ b/extr.c
@@ -59,7 +59,7 @@ int save_attachments(int pageno, char *targetdir)
 					sprintf(pathname, "%s/%s", targetdir, name);
 					FILE *fout = fopen(pathname, "w");
 					if (!fout) {
-						fprintf(stderr, "extr: cannot write to file %s\n", name);
+						fprintf(stderr, "extr: cannot write to file %s\n", pathname);
 						exit(1);
 					}
 					dump_stream(pdf_to_num(f_obj), fout);

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -68,7 +68,7 @@ for ((i=1 ; i <= $numargs ; i++))
 do
 	fullname=$(readlink -f "$1")
 	if [ ! -r "$fullname" ] ; then
-		echo "$progname: file \"$fullname\" does not exist" >&2
+		echo "$progname: cannot access the file \"$fullname\"" >&2
 		usage
 	fi
 	infiles[$infcount]="$fullname"

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -67,7 +67,7 @@ numargs=$#
 for ((i=1 ; i <= $numargs ; i++))
 do
 	fullname=$(readlink -f "$1")
-	if [ ! -f "$fullname" ] ; then
+	if [ ! -r "$fullname" ] ; then
 		echo "$progname: file \"$fullname\" does not exist" >&2
 		usage
 	fi


### PR DESCRIPTION
1. In extr.c the error message should use the correct full pathname, not just the base filename.
2. In pdfattach the check for existence of input files should be replaced with the check for read access to them.
