### PR TITLE
Implements "comics mode"

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -5,6 +5,7 @@ DJVUReader = UniReader:new{}
 function DJVUReader:setDefaults()
 	self.show_overlap_enable = true
 	self.show_links_enable = false
+	self.comics_mode_enable = false
 end
 
 -- check DjVu magic string to validate

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -325,6 +325,7 @@ end
 function KOPTReader:adjustCommands()
 	self.commands:del(KEY_A, nil,"A")
 	self.commands:del(KEY_A, MOD_SHIFT, "A")
+	self.commands:del(KEY_C, nil,"C")
 	self.commands:del(KEY_D, nil,"D")
 	self.commands:del(KEY_D, MOD_SHIFT, "D")
 	self.commands:del(KEY_S, nil,"S")

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -295,6 +295,7 @@ end
 function KOPTReader:setDefaults()
     self.show_overlap_enable = true
     self.show_links_enable = false
+    self.comics_mode_enable = false
 end
 
 -- backup global variables from UniReader

--- a/picviewer.lua
+++ b/picviewer.lua
@@ -5,6 +5,7 @@ PICViewer = UniReader:new{}
 function PICViewer:setDefaults()
 	self.show_overlap_enable = false
 	self.show_links_enable = false
+  self.comics_mode_enable = false
 end
 
 function PICViewer:open(filename)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1419,10 +1419,12 @@ function UniReader:show(no)
 	fb.bb:blitFrom(bb, self.dest_x, self.dest_y, offset_x, offset_y, width, height)
 
 	Debug("self.show_overlap", self.show_overlap)
-	if self.show_overlap < 0 and self.show_overlap_enable and not self.comics_mode_enable then
-		fb.bb:dimRect(0,0, width, self.dest_y - self.show_overlap)
-	elseif self.show_overlap > 0 and self.show_overlap_enable and not self.comics_mode_enable then
-		fb.bb:dimRect(0,self.dest_y + height - self.show_overlap, width, self.show_overlap)
+       if self.show_overlap_enable and not self.comics_mode_enable then
+               if self.show_overlap < 0 then
+                       fb.bb:dimRect(0,0, width, self.dest_y - self.show_overlap)
+               elseif self.show_overlap > 0 then
+                       fb.bb:dimRect(0,self.dest_y + height - self.show_overlap, width, self.show_overlap)
+               end
 	end
 	self.show_overlap = 0
 

--- a/unireader.lua
+++ b/unireader.lua
@@ -68,6 +68,7 @@ UniReader = {
 	show_overlap = 0,
 	show_overlap_enable,
 	show_links_enable,
+	comics_mode_enable,
 
 	-- the document:
 	doc = nil,
@@ -956,6 +957,7 @@ end
 function UniReader:setDefaults()
 	self.show_overlap_enable = true
 	self.show_links_enable = true
+	self.comics_mode_enable = false
 end
 
 -- This is a low-level method that can be shared with all readers.
@@ -1002,6 +1004,10 @@ function UniReader:loadSettings(filename)
 		tmp = self.settings:readSetting("show_links_enable")
 		if tmp ~= nil then
 			self.show_links_enable = tmp
+		end
+		tmp = self.settings:readSetting("comics_mode_enable")
+		if tmp ~= nil then
+			self.comics_mode_enable = tmp
 		end
 
 		-- other parameters are reader-specific --> @TODO: move to proper place, like loadSpecialSettings()
@@ -1413,9 +1419,9 @@ function UniReader:show(no)
 	fb.bb:blitFrom(bb, self.dest_x, self.dest_y, offset_x, offset_y, width, height)
 
 	Debug("self.show_overlap", self.show_overlap)
-	if self.show_overlap < 0 and self.show_overlap_enable then
+	if self.show_overlap < 0 and self.show_overlap_enable and not self.comics_mode_enable then
 		fb.bb:dimRect(0,0, width, self.dest_y - self.show_overlap)
-	elseif self.show_overlap > 0 and self.show_overlap_enable then
+	elseif self.show_overlap > 0 and self.show_overlap_enable and not self.comics_mode_enable then
 		fb.bb:dimRect(0,self.dest_y + height - self.show_overlap, width, self.show_overlap)
 	end
 	self.show_overlap = 0
@@ -1604,6 +1610,13 @@ function UniReader:nextView()
 			-- goto next view of current page
 			self.offset_y = self.offset_y - G_height
 							+ self.pan_overlap_vertical
+
+			if self.comics_mode_enable then
+				if self.offset_y < self.min_offset_y then
+					self.offset_y = self.min_offset_y - 0
+				end
+			end
+
 			self.show_overlap = -self.pan_overlap_vertical -- top < 0
 		end
 	else
@@ -1634,6 +1647,13 @@ function UniReader:prevView()
 			-- goto previous view of current page
 			self.offset_y = self.offset_y + G_height
 							- self.pan_overlap_vertical
+
+			if self.comics_mode_enable then
+				if self.offset_y > self.content_top then
+					self.offset_y = self.content_top + 0
+				end
+			end
+
 			self.show_overlap = self.pan_overlap_vertical -- bottom > 0
 		end
 	else
@@ -2618,6 +2638,19 @@ function UniReader:addAllCommands()
 				InfoMessage:inform("Turning overlap OFF", nil, 1, MSG_AUX)
 			end
 			self.settings:saveSetting("show_overlap_enable", unireader.show_overlap_enable)
+			self:redrawCurrentPage()
+		end)
+
+	self.commands:add(KEY_C, nil, "C",
+		"toggle comics mode on/off",
+		function(unireader)
+			unireader.comics_mode_enable = not unireader.comics_mode_enable
+			if unireader.comics_mode_enable then
+				InfoMessage:inform("Comics mode ON", nil, 1, MSG_AUX)
+			else
+				InfoMessage:inform("Comics mode OFF", nil, 1, MSG_AUX)
+			end
+			self.settings:saveSetting("comics_mode_enable", unireader.comics_mode_enable)
 			self:redrawCurrentPage()
 		end)
 


### PR DESCRIPTION
This is bacically my hack no.3, described here: http://www.mobileread.com/forums/showpost.php?p=2215362&postcount=618, but a bit improved, and implemented like a toggle. It's very useful for reading comics, so thus I called it comics mode. 

When I read pdfs, I usually manually set bbox, and then use shift-s. Without this PR, it usually shows a pdf page on 2 screens: on 1st screen the top of the page is lined up with top of the screen. Then, when I press pg_fw, it displays second part of the page (which is usually 3 or 4 lines) at the top of the screen, with the rest of the screen gray. With this PR, when you press pg_fw it will display the 2nd screen with bottom of the page lined up with the bottom of the screen. The whole screen will be filled with the content of the page (most of it was on the 1st screen too). Of course, one can do this with panning, but I find reading it like this much more natural.

Shortcut key for comics mode is C.
