### PR TITLE
Simple Memory Usage Indicator

### DIFF
--- a/djvureader.lua
+++ b/djvureader.lua
@@ -114,14 +114,16 @@ function DJVUReader:_drawReadingInfo()
 	local load_percent = self.pageno/numpages
 	local face = Font:getFace("rifont", 20)
 	local page_width, page_height, page_dpi, page_gamma, page_type = self.doc:getPageInfo(self.pageno)
+	local rss, data, totalvm = util.memusage()
 
 	-- display memory, time, battery and DjVu info on top of page
 	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
-		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k, "..
-		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k", true)
-	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
+		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k "..
+		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k "..
+        rss.."/"..data.."/"..totalvm.."k", true)
+	local txt = os.date("%H:%M").." ["..BatteryLevel().."]"
 	local w = sizeUtf8Text(0, width, face, txt, true).x
 	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,

--- a/picviewer.lua
+++ b/picviewer.lua
@@ -20,13 +20,15 @@ function PICViewer:_drawReadingInfo()
 	local width = G_width
 	local face = Font:getFace("rifont", 20)
 	local page_width, page_height, page_components = self.doc:getOriginalPageSize()
+	local rss, data, totalvm = util.memusage()
 
 	-- display memory, time, battery and image info on top of page
 	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
-		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k", true)
-	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
+		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k "..
+        rss.."/"..data.."/"..totalvm.."k", true)
+	local txt = os.date("%H:%M").." ["..BatteryLevel().."]"
 	local w = sizeUtf8Text(0, width, face, txt, true).x
 	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,

--- a/unireader.lua
+++ b/unireader.lua
@@ -2189,6 +2189,7 @@ function UniReader:_drawReadingInfo()
 	local width, height = G_width, G_height
 	local numpages = self.doc:getPages()
 	local load_percent = (self.pageno / numpages)
+	local rss, data, totalvm = util.memusage()
 	-- changed to be the same font group as originaly intended
 	local face = Font:getFace("rifont", 20)
 
@@ -2196,9 +2197,10 @@ function UniReader:_drawReadingInfo()
 	fb.bb:paintRect(0, 0, width, 15+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
-		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 )..
-		" "..math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k", true)
-	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
+		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k "..
+		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k "..
+        rss.."/"..data.."/"..totalvm.."k", true)
+	local txt = os.date("%H:%M").." ["..BatteryLevel().."]"
 	local w = sizeUtf8Text(0, width, face, txt, true).x
 	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 

--- a/util.c
+++ b/util.c
@@ -17,7 +17,6 @@
 */
 
 #include <sys/time.h>
-#include <sys/types.h>
 #include <sys/statvfs.h>
 #include <unistd.h>
 #include <string.h>
@@ -47,21 +46,19 @@ static int util_usleep(lua_State *L) {
 /* returns three numbers: RSS, Data, TotalVM */
 static int memusage(lua_State *L) {
 	char buf[512];
-	FILE *fp;
 	int rss = -1, data = -1, totalvm = -1;
-
-	sprintf(buf, "/proc/%d/status", getpid());
-	fp = fopen(buf, "r");
+	FILE *fp = fopen("/proc/self/status", "r");
 	if (fp) {
 		while (fgets(buf, sizeof(buf), fp) != NULL) {
 			char *ptr = NULL;
 			if (ptr = strstr(buf, "VmSize:")) {
-				sscanf(ptr + strlen("VmSize:\t"), "%d kB", &totalvm);
+				sscanf(ptr, "VmSize:\t%d kB", &totalvm);
 			} else if (ptr = strstr(buf, "VmRSS:")) {
-				sscanf(ptr + strlen("VmRSS:\t"), "%d kB", &rss);
+				sscanf(ptr, "VmRSS:\t%d kB", &rss);
 			} else if (ptr = strstr(buf, "VmData:")) {
-				sscanf(ptr + strlen("VmData:\t"), "%d kB", &data);
+				sscanf(ptr, "VmData:\t%d kB", &data);
 			}
+			if (rss != -1 && data != -1 && totalvm != -1) break;
 		}
 		fclose(fp);
 	}

--- a/util.c
+++ b/util.c
@@ -56,11 +56,11 @@ static int memusage(lua_State *L) {
 		while (fgets(buf, sizeof(buf), fp) != NULL) {
 			char *ptr = NULL;
 			if (ptr = strstr(buf, "VmSize:")) {
-				sscanf(ptr + strlen("VmSize:\t"), "\t%d kB", &totalvm);
+				sscanf(ptr + strlen("VmSize:\t"), "%d kB", &totalvm);
 			} else if (ptr = strstr(buf, "VmRSS:")) {
-				sscanf(ptr + strlen("VmRSS:\t"), "\t%d kB", &rss);
+				sscanf(ptr + strlen("VmRSS:\t"), "%d kB", &rss);
 			} else if (ptr = strstr(buf, "VmData:")) {
-				sscanf(ptr + strlen("VmData:\t"), "\t%d kB", &data);
+				sscanf(ptr + strlen("VmData:\t"), "%d kB", &data);
 			}
 		}
 		fclose(fp);


### PR DESCRIPTION
The function `util.c:memusage()` returns three numbers like this:

```
rss, data, totalvm = util.memusage()
```

The sizes are in kilobytes and obtained from `/proc/self/status` file. Tested both on the emulator and Kindle.

I shortened the date/time format to just "%H:%M" --- if someone really needs to see the full date/time then he can enter `os.date()` in the calculator :)
