### PR TITLE
Build djvulibre as a shared library

### DIFF
--- a/kpdf.sh
+++ b/kpdf.sh
@@ -21,6 +21,7 @@ fi
 # stop cvm
 killall -stop cvm
 
+export LD_LIBRARY_PATH=`pwd`/libs
 # finally call reader
 ./reader.lua "$1" 2> /mnt/us/kindlepdfviewer/crash.log || cat /mnt/us/kindlepdfviewer/crash.log
 


### PR DESCRIPTION
The idea is to build ALL that we currently link statically as a shared library.
This PR deals with djvulibre (one thing at a time).

When building for the emulator it places the library in `libs-emu` subdirectory so you have to do this before running `reader.lua`

```
$ export LD_LIBRARY_PATH=`pwd`/libs-emu
```

When running on Kindle this is done automatically in the script `kpdf.sh`.
