### PR TITLE
Add simple memory usage indicator.

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -384,22 +384,31 @@ end
 ----------------------------------------------------
 -- used in CREReader:showMenu()
 function CREReader:_drawReadingInfo()
-	local ypos = G_height - 50
+	local width = G_width
 	local load_percent = self.percent/100
+	local rss, data, stack, lib, totalvm = memUsage()
+	local face = Font:getFace("rifont", 20)
 
-	fb.bb:paintRect(0, ypos, G_width, 50, 0)
+	-- display page number, date and memory stats at the top
+	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
+	renderUtf8Text(fb.bb, 10, 15+6, face, "p."..self.pageno.."/"..self.doc:getPages(), true)
+	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
+	local w = sizeUtf8Text(0, width, face, txt, true).x
+	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
+	renderUtf8Text(fb.bb, 10, 15+6+22, face,
+		"RSS:"..rss.." DAT:"..data.." STK:"..stack.." LIB:"..lib.." TOT:"..totalvm.."k", true)
+
+	-- display reading progress at the bottom
+	local ypos = G_height - 50
+	fb.bb:paintRect(0, ypos, width, 50, 0)
 
 	ypos = ypos + 15
-	local face = Font:getFace("rifont", 20)
 
 	local cur_section = self:getTocTitleOfCurrentPage()
 	if cur_section ~= "" then
-		cur_section = "  Section: "..cur_section
+		cur_section = "  Sec: "..cur_section
 	end
-	--[[ NuPogodi, 30.08.12: to show or not to show (page numbers in info message)?
-		"  Page: "..self.pageno.." of "..self.doc:getPages()
-	TODO: similar bar at the page top with the book author, book title, etc. ]]
-	local footer = "Position: "..load_percent.."%"..cur_section
+	local footer = load_percent.."%"..cur_section
 	if sizeUtf8Text(10, fb.bb:getWidth(), face, footer, true).x < (fb.bb:getWidth() - 20) then
 		renderUtf8Text(fb.bb, 10, ypos+6, face, footer, true)
 	else
@@ -408,7 +417,7 @@ function CREReader:_drawReadingInfo()
 		renderUtf8Text(fb.bb, gapx, ypos+6, face, "...", true)
 	end
 	ypos = ypos + 15
-	blitbuffer.progressBar(fb.bb, 10, ypos, G_width - 20, 15, 5, 4, load_percent/100, 8)
+	blitbuffer.progressBar(fb.bb, 10, ypos, width - 20, 15, 5, 4, load_percent/100, 8)
 end
 
 function CREReader:showMenu()

--- a/djvureader.lua
+++ b/djvureader.lua
@@ -113,18 +113,21 @@ function DJVUReader:_drawReadingInfo()
 	local numpages = self.doc:getPages()
 	local load_percent = self.pageno/numpages
 	local face = Font:getFace("rifont", 20)
+	local rss, data, stack, lib, totalvm = memUsage()
 	local page_width, page_height, page_dpi, page_gamma, page_type = self.doc:getPageInfo(self.pageno)
 
 	-- display memory, time, battery and DjVu info on top of page
-	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
+	fb.bb:paintRect(0, 0, width, 60+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
-		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k, "..
+		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k "..
 		math.ceil( self.doc:getCacheSize() / 1024 ).."/"..math.ceil( self.cache_document_size / 1024 ).."k", true)
 	local txt = os.date("%a %d %b %Y %T").." ["..BatteryLevel().."]"
 	local w = sizeUtf8Text(0, width, face, txt, true).x
 	renderUtf8Text(fb.bb, width - w - 10, 15+6, face, txt, true)
 	renderUtf8Text(fb.bb, 10, 15+6+22, face,
+	"RSS:"..rss.." DAT:"..data.." STK:"..stack.." LIB:"..lib.." TOT:"..totalvm.."k", true)
+	renderUtf8Text(fb.bb, 10, 15+6+44, face,
 		"Gm:"..string.format("%.1f",self.globalgamma).." ["..tostring(page_gamma).."], "..
 		tostring(page_width).."x"..tostring(page_height)..", "..
 		string.format("%.1fx, ", self.globalzoom)..
@@ -140,7 +143,7 @@ function DJVUReader:_drawReadingInfo()
 		cur_section = "Sec: "..cur_section
 	end
 	renderUtf8Text(fb.bb, 10, ypos+6, face,
-		"Page: "..self.pageno.."/"..numpages.."   "..cur_section, true)
+		"p."..self.pageno.."/"..numpages.."   "..cur_section, true)
 
 	ypos = ypos + 15
 	blitbuffer.progressBar(fb.bb, 10, ypos, width-20, 15,

--- a/picviewer.lua
+++ b/picviewer.lua
@@ -19,10 +19,11 @@ end
 function PICViewer:_drawReadingInfo()
 	local width = G_width
 	local face = Font:getFace("rifont", 20)
+	local rss, data, stack, lib, totalvm = memUsage()
 	local page_width, page_height, page_components = self.doc:getOriginalPageSize()
 
 	-- display memory, time, battery and image info on top of page
-	fb.bb:paintRect(0, 0, width, 40+6*2, 0)
+	fb.bb:paintRect(0, 0, width, 60+6*2, 0)
 	renderUtf8Text(fb.bb, 10, 15+6, face,
 		"M: "..
 		math.ceil( self.cache_current_memsize / 1024 ).."/"..math.ceil( self.cache_max_memsize / 1024 ).."k", true)
@@ -34,6 +35,8 @@ function PICViewer:_drawReadingInfo()
 		tostring(page_width).."x"..tostring(page_height).."x"..tostring(page_components)..
 		" ("..tostring(math.ceil(page_width*page_height*page_components/1024)).."k), "..
 		string.format("%.1fx", self.globalzoom), true)
+	renderUtf8Text(fb.bb, 10, 15+6+44, face,
+	"RSS:"..rss.." DAT:"..data.." STK:"..stack.." LIB:"..lib.." TOT:"..totalvm.."k", true)
 end
 
 function PICViewer:init()

--- a/unireader.lua
+++ b/unireader.lua
@@ -2188,29 +2188,31 @@ end
 function memUsage()
 	local rss, data, stack, lib, totalvm = -1, -1, -1, -1, -1
 	local file = io.open("/proc/self/status", "r")
-	for line in file:lines() do
-		local s, n
-		s, n = line:gsub("VmRSS:%s-(%d+) kB", "%1")	
-		if n ~= 0 then rss = tonumber(s) end
+	if file then
+		for line in file:lines() do
+			local s, n
+			s, n = line:gsub("VmRSS:%s-(%d+) kB", "%1")	
+			if n ~= 0 then rss = tonumber(s) end
 
-		s, n = line:gsub("VmData:%s-(%d+) kB", "%1")	
-		if n ~= 0 then data = tonumber(s) end
+			s, n = line:gsub("VmData:%s-(%d+) kB", "%1")	
+			if n ~= 0 then data = tonumber(s) end
 
-		s, n = line:gsub("VmStk:%s-(%d+) kB", "%1")	
-		if n ~= 0 then stack = tonumber(s) end
+			s, n = line:gsub("VmStk:%s-(%d+) kB", "%1")	
+			if n ~= 0 then stack = tonumber(s) end
 
-		s, n = line:gsub("VmLib:%s-(%d+) kB", "%1")	
-		if n ~= 0 then lib = tonumber(s) end
+			s, n = line:gsub("VmLib:%s-(%d+) kB", "%1")	
+			if n ~= 0 then lib = tonumber(s) end
 
-		s, n = line:gsub("VmSize:%s-(%d+) kB", "%1")	
-		if n ~= 0 then totalvm = tonumber(s) end
+			s, n = line:gsub("VmSize:%s-(%d+) kB", "%1")	
+			if n ~= 0 then totalvm = tonumber(s) end
 
-		if rss ~= -1 and data ~= -1 and stack ~= -1 
-		  and lib ~= -1 and totalvm ~= -1 then
-			break
-		end
-	end
-	file:close()
+			if rss ~= -1 and data ~= -1 and stack ~= -1 
+			  and lib ~= -1 and totalvm ~= -1 then
+				break
+			end
+		end -- for line in file:lines()
+		file:close()
+	end -- if file
 	return rss, data, stack, lib, totalvm
 end
 

--- a/unireader.lua
+++ b/unireader.lua
@@ -2187,7 +2187,8 @@ end
 -- returns five numbers (in KB): rss, data, stack, lib, totalvm
 function memUsage()
 	local rss, data, stack, lib, totalvm = -1, -1, -1, -1, -1
-	for line in io.lines("/proc/self/status") do
+	local file = io.open("/proc/self/status", "r")
+	for line in file:lines() do
 		local s, n
 		s, n = line:gsub("VmRSS:%s-(%d+) kB", "%1")	
 		if n ~= 0 then rss = tonumber(s) end
@@ -2209,6 +2210,7 @@ function memUsage()
 			break
 		end
 	end
+	file:close()
 	return rss, data, stack, lib, totalvm
 end
 


### PR DESCRIPTION
The function memUsage() parses the file "/proc/self/status" and extracts the sizes (in KB) of RSS, Data, Stack, Lib and TotalVM. These are displayed when Menu button is pressed inside readers.

(Also, the info displayed by crereader is tidied up, e.g. there is no need for "Pos: " prefix before showing percentage as it is obvious and just wastes space that can otherwise be used for the section title. Also, show the page numbers and total number of pages even though these are "virtual".)
