### PR TITLE
Link against libraries in libs and libs-emu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,11 @@ ifdef EMULATE_READER
 	endif
 	CFLAGS+= $(HOST_ARCH)
 	CXXFLAGS+= $(HOST_ARCH)
+	LIBDIR=libs-emu
 else
 	CFLAGS+= $(ARM_ARCH) $(ARM_BACKWARD_COMPAT_CFLAGS)
 	CXXFLAGS+= $(ARM_ARCH) $(ARM_BACKWARD_COMPAT_CFLAGS) $(ARM_BACKWARD_COMPAT_CXXFLAGS)
+	LIBDIR=libs
 endif
 
 # standard includes
@@ -140,7 +142,7 @@ kpdfview: kpdfview.o einkfb.o pdf.o k2pdfopt.o blitbuffer.o drawcontext.o input.
 		$(STATICLIBSTDCPP) \
 		$(LDFLAGS) \
 		-o $@ \
-		-lm -ldl -lpthread -ldjvulibre -ljpeg -L$(MUPDFLIBDIR) -L$(DJVULIBDIR)\
+		-lm -ldl -lpthread -ldjvulibre -ljpeg -L$(MUPDFLIBDIR) -L$(LIBDIR)\
 		$(EMU_LDFLAGS) \
 		$(DYNAMICLIBSTDCPP)
 
@@ -212,11 +214,7 @@ clean:
 	rm -f *.o kpdfview slider_watcher extr
 
 cleanthirdparty:
-ifdef EMULATE_READER
-	rm -rf libs-emu ; mkdir libs-emu
-else
-	rm -rf libs ; mkdir libs
-endif
+	rm -rf $(LIBDIR) ; mkdir $(LIBDIR)
 	$(MAKE) -C $(LUADIR) CC="$(HOSTCC)" CFLAGS="$(BASE_CFLAGS)" clean
 	$(MAKE) -C $(MUPDFDIR) build="release" clean
 	$(MAKE) -C $(CRENGINEDIR)/thirdparty/antiword clean
@@ -247,15 +245,12 @@ $(DJVULIBS):
 	mkdir -p $(DJVUDIR)/build
 ifdef EMULATE_READER
 	cd $(DJVUDIR)/build && CC="$(HOSTCC)" CXX="$(HOSTCXX)" CFLAGS="$(HOSTCFLAGS)" CXXFLAGS="$(HOSTCFLAGS)" LDFLAGS="$(LDFLAGS)" ../configure --disable-desktopfiles --disable-static --enable-shared --disable-xmltools --disable-largefile
-	$(MAKE) -C $(DJVUDIR)/build
-	test -d libs-emu || mkdir libs-emu
-	cp -a $(DJVULIBDIR)/libdjvulibre.so* libs-emu
 else
 	cd $(DJVUDIR)/build && CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" ../configure --disable-desktopfiles --disable-static --enable-shared --host=$(CHOST) --disable-xmltools --disable-largefile
-	$(MAKE) -C $(DJVUDIR)/build
-	test -d libs || mkdir libs
-	cp $(DJVULIBDIR)/libdjvulibre.so.21 libs
 endif
+	$(MAKE) -C $(DJVUDIR)/build
+	test -d $(LIBDIR) || mkdir $(LIBDIR)
+	cp -a $(DJVULIBDIR)/libdjvulibre.so* $(LIBDIR)
 
 $(CRENGINELIBS):
 	cd $(KPVCRLIBDIR) && rm -rf CMakeCache.txt CMakeFiles && \
@@ -289,7 +284,7 @@ customupdate: all
 	mkdir -p $(INSTALL_DIR)/{history,screenshots,libs}
 	cp -p README.md COPYING kpdfview extr kpdf.sh $(LUA_FILES) $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/data
-	cp libs/* $(INSTALL_DIR)/libs
+	cp -L libs/libdjvulibre.so.21 $(INSTALL_DIR)/libs
 	$(STRIP) --strip-unneeded $(INSTALL_DIR)/libs/*
 	cp -rpL data/*.css $(INSTALL_DIR)/data
 	cp -rpL fonts $(INSTALL_DIR)


### PR DESCRIPTION
Instead of linking against the location inside the original build tree we should link against the copy in a single place. This makes the build code cleaner and more compact even now and will do even more so when we build more libraries as shared (which is what I am going to attempt next).
