### PR TITLE
more flexible configuration dialog

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -489,9 +489,10 @@ static int reflowPage(lua_State *L) {
 	double contrast = luaL_checknumber(L, 15);
 	int rotation = luaL_checkint(L, 16);
 	double quality = luaL_checknumber(L, 17);
+	double defect_size = luaL_checknumber(L, 18);
 
 	k2pdfopt_set_params(width, height, font_size, page_margin, line_spacing, word_spacing, \
-			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation, quality);
+			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation, quality, defect_size);
 	k2pdfopt_djvu_reflow(page->page_ref, page->doc->context, mode, page->doc->pixelformat);
 	k2pdfopt_rfbmp_size(&width, &height);
 	k2pdfopt_rfbmp_zoom(&dc->zoom);

--- a/djvu.c
+++ b/djvu.c
@@ -487,10 +487,11 @@ static int reflowPage(lua_State *L) {
 	int detect_indent = luaL_checkint(L, 13);
 	int columns = luaL_checkint(L, 14);
 	double contrast = luaL_checknumber(L, 15);
-	int rotation = luaL_checknumber(L, 16);
+	int rotation = luaL_checkint(L, 16);
+	double quality = luaL_checknumber(L, 17);
 
 	k2pdfopt_set_params(width, height, font_size, page_margin, line_spacing, word_spacing, \
-			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation);
+			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation, quality);
 	k2pdfopt_djvu_reflow(page->page_ref, page->doc->context, mode, page->doc->pixelformat);
 	k2pdfopt_rfbmp_size(&width, &height);
 	k2pdfopt_rfbmp_zoom(&dc->zoom);

--- a/k2pdfopt.c
+++ b/k2pdfopt.c
@@ -498,7 +498,8 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 		int wrapping, int straighten, \
 		int justification, int detect_indent,\
 		int columns, double contrast, \
-		int rotation, double quality) {
+		int rotation, double quality, \
+		double defect_size) {
 	dst_userwidth  = bb_width; // dst_width is adjusted in adjust_params_init
 	dst_userheight = bb_height;
 	zoom_value = font_size;
@@ -511,6 +512,7 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 	gamma_correction = contrast;  // contrast is only used by k2pdfopt_mupdf_reflow
 	src_rot = rotation;
 	src_dpi = (int)300*quality;
+	defect_size_pts = defect_size;
 
 	// margin
 	dst_mar = page_margin;

--- a/k2pdfopt.c
+++ b/k2pdfopt.c
@@ -497,7 +497,8 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 		double line_space, double word_space, \
 		int wrapping, int straighten, \
 		int justification, int detect_indent,\
-		int columns, double contrast, int rotation) {
+		int columns, double contrast, \
+		int rotation, double quality) {
 	dst_userwidth  = bb_width; // dst_width is adjusted in adjust_params_init
 	dst_userheight = bb_height;
 	zoom_value = font_size;
@@ -509,6 +510,7 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 	max_columns = columns;
 	gamma_correction = contrast;  // contrast is only used by k2pdfopt_mupdf_reflow
 	src_rot = rotation;
+	src_dpi = (int)300*quality;
 
 	// margin
 	dst_mar = page_margin;
@@ -516,7 +518,7 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 	dst_marbot = -1.0;
 	dst_marleft = -1.0;
 	dst_marright = -1.0;
-	printf("justification:%d", justification);
+
 	// justification
 	if (justification < 0) {
 		dst_justify = -1;
@@ -542,7 +544,7 @@ void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx) {
 
 	double dpp,zoom;
 	zoom = zoom_value;
-	double dpi = 250*zoom;
+	double dpi = 250*zoom*src_dpi/300;
 	do {
 		dpp = dpi / 72.;
 		pix = NULL;

--- a/k2pdfopt.h
+++ b/k2pdfopt.h
@@ -31,7 +31,8 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 		double line_space, double word_space, \
 		int wrapping, int straighten, \
 		int justification, int detect_indent, \
-		int columns, double contrast, int rotation);
+		int columns, double contrast, \
+		int rotation, double quality);
 void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx);
 void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, ddjvu_render_mode_t mode, ddjvu_format_t *fmt);
 void k2pdfopt_rfbmp_size(int *width, int *height);

--- a/k2pdfopt.h
+++ b/k2pdfopt.h
@@ -32,7 +32,8 @@ void k2pdfopt_set_params(int bb_width, int bb_height, \
 		int wrapping, int straighten, \
 		int justification, int detect_indent, \
 		int columns, double contrast, \
-		int rotation, double quality);
+		int rotation, double quality, \
+		double defect_size);
 void k2pdfopt_mupdf_reflow(fz_document *doc, fz_page *page, fz_context *ctx);
 void k2pdfopt_djvu_reflow(ddjvu_page_t *page, ddjvu_context_t *ctx, ddjvu_render_mode_t mode, ddjvu_format_t *fmt);
 void k2pdfopt_rfbmp_size(int *width, int *height);

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -6,13 +6,13 @@ KOPTOptions =  {
 	{
 	name="font_size",
 	option_text="",
-	items_text={"Aa","Aa","Aa","Aa","Aa","Aa","Aa","Aa","Aa"},
-	text_font_size={16,18,22,26,30,34,38,42,46},
-	default_item=5,
-	current_item=5,
+	items_text={"Aa","Aa","Aa","Aa","Aa","Aa","Aa","Aa","Aa","Aa"},
+	text_font_size={14,16,20,23,26,30,34,38,42,46},
+	default_item=6,
+	current_item=6,
 	text_dirty=true,
-	marker_dirty={true, true, true, true, true, true, true, true, true},
-	value={0.2, 0.3, 0.6, 0.8, 1.0, 1.2, 1.6, 2.0, 2.6},
+	marker_dirty={true, true, true, true, true, true, true, true, true, true},
+	value={0.2, 0.3, 0.4, 0.6, 0.8, 1.0, 1.2, 1.6, 2.2, 2.8},
 	show = true,
 	draw_index = nil,},
 	{
@@ -68,6 +68,17 @@ KOPTOptions =  {
 	text_dirty=true,
 	marker_dirty={true, true, true, true},
 	value={0.1, 0.2, 0.375, 0.5},
+	show = true,
+	draw_index = nil,},
+	{
+	name="quality",
+	option_text="Render Quality",
+	items_text={"performance","balanced","quality"},
+	default_item=3,
+	current_item=3,
+	text_dirty=true,
+	marker_dirty={true, true, true},
+	value={0.2, 0.6, 1.0},
 	show = true,
 	draw_index = nil,},
 	{
@@ -133,7 +144,7 @@ KOPTConfig = {
 	HEIGHT = nil,  -- height, updated in run time
 	MARGIN_BOTTOM = 25,  -- window bottom margin
 	OPTION_PADDING_T = 60, -- option top padding
-	OPTION_PADDING_H = 50, -- option horizontal padding
+	OPTION_PADDING_H = 70, -- option horizontal padding
 	OPTION_SPACING_V = 35,	-- options vertical spacing
 	NAME_ALIGN_RIGHT = 0.28, -- align name right to the window width
 	ITEM_ALIGN_LEFT = 0.30,	-- align item left to the window width
@@ -191,7 +202,7 @@ function KOPTConfig:drawOptionItem(xpos, ypos, option_index, item_index, text, f
 	if KOPTOptions[option_index].marker_dirty[item_index] or redraw then
 		--Debug("drawing option:", KOPTOptions[option_index].option_text, "marker:", text)
 		if item_index == KOPTOptions[option_index].current_item then
-			fb.bb:paintRect(xpos, ypos+5, text_len, 3,(option_index == self.current_option) and 15 or 5)
+			fb.bb:paintRect(xpos, ypos+5, text_len, 3,(option_index == self.current_option) and 15 or 6)
 			if refresh then 
 				fb:refresh(1, xpos, ypos+5, text_len, 3)
 			end

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -38,6 +38,17 @@ KOPTOptions =  {
 	show = true,
 	draw_index = nil,},
 	{
+	name="defect_size",
+	option_text="Defect Size",
+	items_text={"small","medium","large"},
+	default_item=1,
+	current_item=1,
+	text_dirty=true,
+	marker_dirty={true, true, true},
+	value={1.0, 2.0, 5.0},
+	show = true,
+	draw_index = nil,},
+	{
 	name="page_margin",
 	option_text="Page Margin",
 	items_text={"small","medium","large"},

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -12,7 +12,31 @@ KOPTOptions =  {
 	current_item=5,
 	text_dirty=true,
 	marker_dirty={true, true, true, true, true, true, true, true, true},
-	value={0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.6, 2.0, 2.6}},
+	value={0.2, 0.3, 0.6, 0.8, 1.0, 1.2, 1.6, 2.0, 2.6},
+	show = true,
+	draw_index = nil,},
+	{
+	name="text_wrap",
+	option_text="Text Wrap",
+	items_text={"enable","disable"},
+	default_item=1,
+	current_item=1,
+	text_dirty=true,
+	marker_dirty={true, true},
+	value={1, 0},
+	show = true,
+	draw_index = nil,},
+	{
+	name="detect_indent",
+	option_text="Indentation",
+	items_text={"enable","disable"},
+	default_item=1,
+	current_item=1,
+	text_dirty=true,
+	marker_dirty={true, true},
+	value={1, 0},
+	show = true,
+	draw_index = nil,},
 	{
 	name="page_margin",
 	option_text="Page Margin",
@@ -21,7 +45,9 @@ KOPTOptions =  {
 	current_item=2,
 	text_dirty=true,
 	marker_dirty={true, true, true},
-	value={0.02, 0.06, 0.10}},
+	value={0.02, 0.06, 0.10},
+	show = false,
+	draw_index = nil,},
 	{
 	name="line_spacing",
 	option_text="Line Spacing",
@@ -30,34 +56,20 @@ KOPTOptions =  {
 	current_item=2,
 	text_dirty=true,
 	marker_dirty={true, true, true},
-	value={1.0, 1.2, 1.4}},
+	value={1.0, 1.2, 1.4},
+	show = false,
+	draw_index = nil,},
 	{
 	name="word_spacing",
 	option_text="Word Spacing",
-	items_text={"smallest","smaller","small","medium","large"},
-	default_item=4,
-	current_item=4,
+	items_text={"smaller","small","medium","large"},
+	default_item=3,
+	current_item=3,
 	text_dirty=true,
-	marker_dirty={true, true, true, true, true},
-	value={0.05, 0.1, 0.2, 0.375, 0.5}},
-	{
-	name="text_wrap",
-	option_text="Text Wrap",
-	items_text={"disable","enable"},
-	default_item=2,
-	current_item=2,
-	text_dirty=true,
-	marker_dirty={true, true},
-	value={0, 1}},
-	{
-	name="detect_indent",
-	option_text="Indentation",
-	items_text={"disable","enable"},
-	default_item=2,
-	current_item=2,
-	text_dirty=true,
-	marker_dirty={true, true},
-	value={0, 1}},
+	marker_dirty={true, true, true, true},
+	value={0.1, 0.2, 0.375, 0.5},
+	show = true,
+	draw_index = nil,},
 	{
 	name="auto_straighten",
 	option_text="Auto Straighten",
@@ -66,7 +78,9 @@ KOPTOptions =  {
 	current_item=1,
 	text_dirty=true,
 	marker_dirty={true, true, true, true},
-	value={0, 0, 5, 10}},
+	value={0, 0, 5, 10},
+	show = true,
+	draw_index = nil,},
 	{
 	name="justification",
 	option_text="Justification",
@@ -75,7 +89,9 @@ KOPTOptions =  {
 	current_item=1,
 	text_dirty=true,
 	marker_dirty={true, true, true, true, true},
-	value={-1,0,1,2,3}},
+	value={-1,0,1,2,3},
+	show = true,
+	draw_index = nil,},
 	{
 	name="max_columns",
 	option_text="Columns",
@@ -84,7 +100,9 @@ KOPTOptions =  {
 	current_item=1,
 	text_dirty=true,
 	marker_dirty={true, true, true, true, true},
-	value={2,1,2,3,4}},
+	value={2,1,2,3,4},
+	show = true,
+	draw_index = nil,},
 	{
 	name="contrast",
 	option_text="Contrast",
@@ -93,7 +111,9 @@ KOPTOptions =  {
 	current_item=3,
 	text_dirty=true,
 	marker_dirty={true, true, true, true, true},
-	value={0.2, 0.4, 1.0, 1.8, 2.6}},
+	value={0.2, 0.4, 1.0, 1.8, 2.6},
+	show = true,
+	draw_index = nil,},
 	{
 	name="screen_rotation",
 	option_text="Screen Rotation",
@@ -102,15 +122,17 @@ KOPTOptions =  {
 	current_item=1,
 	text_dirty=true,
 	marker_dirty={true, true, true, true},
-	value={0, 90, 180, 270}},
+	value={0, 90, 180, 270},
+	show = true,
+	draw_index = nil,},
 }
 
 KOPTConfig = {
 	-- UI constants
 	WIDTH = 550,   -- width
-	HEIGHT = 420,  -- height
+	HEIGHT = nil,  -- height, updated in run time
 	MARGIN_BOTTOM = 25,  -- window bottom margin
-	OPTION_PADDING_T = 50, -- option top padding
+	OPTION_PADDING_T = 60, -- option top padding
 	OPTION_PADDING_H = 50, -- option horizontal padding
 	OPTION_SPACING_V = 35,	-- options vertical spacing
 	NAME_ALIGN_RIGHT = 0.28, -- align name right to the window width
@@ -141,7 +163,8 @@ function KOPTConfig:drawOptionName(xpos, ypos, option_index, text, font_face, re
 	if KOPTOptions[option_index].text_dirty or redraw then
 		--Debug("drawing option name:", KOPTOptions[option_index].option_text)
 		local text_len = sizeUtf8Text(0, G_width, font_face, text, true).x
-		renderUtf8Text(fb.bb, xpos-text_len, ypos+self.OPTION_SPACING_V*(option_index-1), font_face, text, true)
+		local draw_index = KOPTOptions[option_index].draw_index
+		renderUtf8Text(fb.bb, xpos-text_len, ypos+self.OPTION_SPACING_V*(draw_index-1), font_face, text, true)
 	end
 end
 
@@ -150,8 +173,9 @@ function KOPTConfig:drawOptionItem(xpos, ypos, option_index, item_index, text, f
 	local width = self.WIDTH
 	local offset = self.OPTION_PADDING_H+self.ITEM_ALIGN_LEFT*(width-2*self.OPTION_PADDING_H)
 	local item_x_offset = (KOPTOptions[option_index].option_text == "") and self.OPTION_PADDING_H or offset
+	local draw_index = KOPTOptions[option_index].draw_index
 	local xpos = xpos+item_x_offset+self.ITEM_SPACING_H*(item_index-1)+self.text_pos
-	local ypos = ypos+self.OPTION_PADDING_T+self.OPTION_SPACING_V*(option_index-1)
+	local ypos = ypos+self.OPTION_PADDING_T+self.OPTION_SPACING_V*(draw_index-1)
 	
 	if KOPTOptions[option_index].text_font_size then
 		font_face = Font:getFace("cfont", KOPTOptions[option_index].text_font_size[item_index])
@@ -184,27 +208,49 @@ end
 function KOPTConfig:drawOptions(xpos, ypos, name_font, item_font, redraw, refresh)
 	local width, height = self.WIDTH, self.HEIGHT
 	for i=1,#KOPTOptions do
-		self:drawOptionName(xpos, ypos, i, KOPTOptions[i].option_text, name_font, redraw)
-		for j=1,#KOPTOptions[i].items_text do
-			self:drawOptionItem(xpos, ypos, i, j, KOPTOptions[i].items_text[j], item_font, redraw, refresh)
+		if KOPTOptions[i].show then
+			self:drawOptionName(xpos, ypos, i, KOPTOptions[i].option_text, name_font, redraw)
+			for j=1,#KOPTOptions[i].items_text do
+				self:drawOptionItem(xpos, ypos, i, j, KOPTOptions[i].items_text[j], item_font, redraw, refresh)
+			end
+			KOPTOptions[i].text_dirty = false
 		end
-		KOPTOptions[i].text_dirty = false
 	end
 end
 
 function KOPTConfig:makeDefault(configurable)
+	local draw_index = 1
+	self.HEIGHT = self.OPTION_PADDING_T
 	for i=1,#KOPTOptions do
+		-- update draw index of each option in run time
+		if KOPTOptions[i].show then
+			KOPTOptions[i].draw_index = draw_index
+			draw_index = draw_index + 1
+		end
+		-- update window height
+		if KOPTOptions[i].show then
+			self.HEIGHT = self.HEIGHT + self.OPTION_SPACING_V
+		end
+		-- make each option and marker dirty
 		KOPTOptions[i].text_dirty = true
 		for j=1,#KOPTOptions[i].items_text do
 			KOPTOptions[i].marker_dirty[j] = true
 		end
+		-- make current index according to configurable table
 		local option = KOPTOptions[i].name
 		local value = configurable[option]
+		local min_diff = math.abs(value - KOPTOptions[i].value[1])
 		KOPTOptions[i].current_item = KOPTOptions[i].default_item
 		for index, val in pairs(KOPTOptions[i].value) do
 			if val == value then
 				KOPTOptions[i].current_item = index
 				break
+			else
+				diff = math.abs(value - val)
+				if diff <= min_diff then
+					min_diff = diff
+					KOPTOptions[i].current_item = index
+				end
 			end
 		end
 	end
@@ -278,8 +324,10 @@ function KOPTConfig:addAllCommands()
 		"next item",
 		function(self)
 			local last_option = self.current_option
-			self.current_option = (self.current_option + #KOPTOptions + 1)%#KOPTOptions
-			self.current_option = (self.current_option == 0) and #KOPTOptions or self.current_option
+			repeat
+				self.current_option = (self.current_option + #KOPTOptions + 1)%#KOPTOptions
+				self.current_option = (self.current_option == 0) and #KOPTOptions or self.current_option
+			until KOPTOptions[self.current_option].show
 			
 			last_option_item = KOPTOptions[last_option].current_item
 			KOPTOptions[last_option].marker_dirty[last_option_item] = true
@@ -291,8 +339,10 @@ function KOPTConfig:addAllCommands()
 		"previous item",
 		function(self)
 			local last_option = self.current_option
-			self.current_option = (self.current_option + #KOPTOptions - 1)%#KOPTOptions
-			self.current_option = (self.current_option == 0) and #KOPTOptions or self.current_option
+			repeat
+				self.current_option = (self.current_option + #KOPTOptions - 1)%#KOPTOptions
+				self.current_option = (self.current_option == 0) and #KOPTOptions or self.current_option
+			until KOPTOptions[self.current_option].show
 			
 			last_option_item = KOPTOptions[last_option].current_item
 			KOPTOptions[last_option].marker_dirty[last_option_item] = true

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -9,6 +9,7 @@ Configurable = {
 	word_spacing = 0.375,
 	quality = 1.0,
 	text_wrap = 1,
+	defect_size = 1.0,
 	detect_indent = 1,
 	auto_straighten = 0,
 	justification = -1,
@@ -187,7 +188,12 @@ function KOPTReader:drawOrCache(no, preCache)
 	local screen_rotation = self.configurable.screen_rotation
 	local detect_indent = self.configurable.detect_indent
 	local quality = self.configurable.quality
-	self.fullwidth, self.fullheight, self.reflow_zoom = page:reflow(dc, self.render_mode, width, height, font_size, page_margin, line_spacing, word_spacing, text_wrap, auto_straighten, justification, detect_indent, max_columns, contrast, screen_rotation, quality)
+	local defect_size = self.configurable.defect_size
+	local fullwidth, fullheight, zoom = page:reflow(dc, self.render_mode, width, height, font_size, 
+										 page_margin, line_spacing, word_spacing, text_wrap, auto_straighten, 
+										 justification, detect_indent, max_columns, contrast, screen_rotation, 
+										 quality, defect_size)
+	self.fullwidth, self.fullheight, self.reflow_zoom = fullwidth, fullheight, zoom
 	Debug("page::reflowPage:", "fullwidth:", self.fullwidth, "fullheight:", self.fullheight)
 	
 	if (self.fullwidth * self.fullheight / 2) <= max_cache then

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -7,6 +7,7 @@ Configurable = {
 	page_margin = 0.06,
 	line_spacing = 1.2,
 	word_spacing = 0.375,
+	quality = 1.0,
 	text_wrap = 1,
 	detect_indent = 1,
 	auto_straighten = 0,
@@ -185,7 +186,8 @@ function KOPTReader:drawOrCache(no, preCache)
 	local auto_straighten = self.configurable.auto_straighten
 	local screen_rotation = self.configurable.screen_rotation
 	local detect_indent = self.configurable.detect_indent
-	self.fullwidth, self.fullheight, self.reflow_zoom = page:reflow(dc, self.render_mode, width, height, font_size, page_margin, line_spacing, word_spacing, text_wrap, auto_straighten, justification, detect_indent, max_columns, contrast, screen_rotation)
+	local quality = self.configurable.quality
+	self.fullwidth, self.fullheight, self.reflow_zoom = page:reflow(dc, self.render_mode, width, height, font_size, page_margin, line_spacing, word_spacing, text_wrap, auto_straighten, justification, detect_indent, max_columns, contrast, screen_rotation, quality)
 	Debug("page::reflowPage:", "fullwidth:", self.fullwidth, "fullheight:", self.fullheight)
 	
 	if (self.fullwidth * self.fullheight / 2) <= max_cache then

--- a/pdf.c
+++ b/pdf.c
@@ -527,10 +527,11 @@ static int reflowPage(lua_State *L) {
 	int detect_indent = luaL_checkint(L, 13);
 	int columns = luaL_checkint(L, 14);
 	double contrast = luaL_checknumber(L, 15);
-	int rotation = luaL_checknumber(L, 16);
+	int rotation = luaL_checkint(L, 16);
+	double quality = luaL_checknumber(L, 17);
 
 	k2pdfopt_set_params(width, height, font_size, page_margin, line_spacing, word_spacing, \
-			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation);
+			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation, quality);
 	k2pdfopt_mupdf_reflow(page->doc->xref, page->page, page->doc->context);
 	k2pdfopt_rfbmp_size(&width, &height);
 	k2pdfopt_rfbmp_zoom(&dc->zoom);

--- a/pdf.c
+++ b/pdf.c
@@ -529,9 +529,10 @@ static int reflowPage(lua_State *L) {
 	double contrast = luaL_checknumber(L, 15);
 	int rotation = luaL_checkint(L, 16);
 	double quality = luaL_checknumber(L, 17);
+	double defect_size = luaL_checknumber(L, 18);
 
 	k2pdfopt_set_params(width, height, font_size, page_margin, line_spacing, word_spacing, \
-			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation, quality);
+			text_wrap, straighten, justification, detect_indent, columns, contrast, rotation, quality, defect_size);
 	k2pdfopt_mupdf_reflow(page->doc->xref, page->page, page->doc->context);
 	k2pdfopt_rfbmp_size(&width, &height);
 	k2pdfopt_rfbmp_zoom(&dc->zoom);


### PR DESCRIPTION
Each option can be configured to show or not and the height of the config dialog is updated accordingly. By default the page margin and line spacing is not drawn to save dialog space. Because these two options just make minorest differences to the view of reflowed pages and the default medium values should work in most case. Even so users can still change the visibility of these two options by editing the `KOPTOptions` table.
