### PR TITLE
rewrite emu mode input handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ fetchthirdparty:
 	cd popen-noshell && test -f Makefile || patch -N -p0 < popen_noshell-buildfix.patch
 
 clean:
-	rm -f *.o kpdfview slider_watcher extr
+	rm -f *.o kpdfview slider_watcher extr emu_event
 
 cleanthirdparty:
 	rm -rf $(LIBDIR) ; mkdir $(LIBDIR)

--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -240,7 +240,8 @@ Input = {
 function Input:init()
 	if util.isEmulated()==1 then
 		-- dummy call that will initialize SDL input handling
-		input.open("")
+		os.execute("rm -f emu_event && mkfifo emu_event")
+		input.open("emu_event")
 		-- SDL key codes
 		self.event_map = self.sdl_event_map
 	else
@@ -292,7 +293,7 @@ function Input:waitEvent(timeout_us, timeout_s)
 		end
 		DEBUG("got error waiting for events:", ev)
 		if ev ~= "Waiting for input failed: 4\n" then
-			-- we abort if the error is not EINTR
+			-- we only abort if the error is not EINTR
 			break
 		end
 	end

--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -239,7 +239,6 @@ Input = {
 
 function Input:init()
 	if util.isEmulated()==1 then
-		-- dummy call that will initialize SDL input handling
 		os.remove("emu_event")
 		os.execute("mkfifo emu_event")
 		input.open("emu_event")

--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -240,7 +240,8 @@ Input = {
 function Input:init()
 	if util.isEmulated()==1 then
 		-- dummy call that will initialize SDL input handling
-		os.execute("rm -f emu_event && mkfifo emu_event")
+		os.remove("emu_event")
+		os.execute("mkfifo emu_event")
 		input.open("emu_event")
 		-- SDL key codes
 		self.event_map = self.sdl_event_map

--- a/input.c
+++ b/input.c
@@ -306,13 +306,13 @@ static int waitForInput(lua_State *L) {
 			if(n == sizeof(struct input_event)) {
 				lua_newtable(L);
 				lua_pushstring(L, "type");
-				lua_pushinteger(L, input.type);
+				lua_pushinteger(L, (int) input.type);
 				lua_settable(L, -3);
 				lua_pushstring(L, "code");
-				lua_pushinteger(L, input.code);
+				lua_pushinteger(L, (int) input.code);
 				lua_settable(L, -3);
 				lua_pushstring(L, "value");
-				lua_pushinteger(L, input.value);
+				lua_pushinteger(L, (int) input.value);
 				lua_settable(L, -3);
 				return 1;
 			} else {

--- a/input.c
+++ b/input.c
@@ -201,6 +201,19 @@ static int closeInputDevices(lua_State *L) {
 #endif
 }
 
+static inline void createInputEvent(lua_State *L, int type, int code, int value) {
+	lua_newtable(L);
+	lua_pushstring(L, "type");
+	lua_pushinteger(L, type);
+	lua_settable(L, -3);
+	lua_pushstring(L, "code");
+	lua_pushinteger(L, code);
+	lua_settable(L, -3);
+	lua_pushstring(L, "value");
+	lua_pushinteger(L, value);
+	lua_settable(L, -3);
+}
+
 static int waitForInput(lua_State *L) {
 	int usecs = luaL_optint(L, 1, -1); // we check for <0 later
 
@@ -238,16 +251,7 @@ static int waitForInput(lua_State *L) {
 
 			n = read(inputfds[i], &input, sizeof(struct input_event));
 			if(n == sizeof(struct input_event)) {
-				lua_newtable(L);
-				lua_pushstring(L, "type");
-				lua_pushinteger(L, (int) input.type);
-				lua_settable(L, -3);
-				lua_pushstring(L, "code");
-				lua_pushinteger(L, (int) input.code);
-				lua_settable(L, -3);
-				lua_pushstring(L, "value");
-				lua_pushinteger(L, (int) input.value);
-				lua_settable(L, -3);
+				createInputEvent(L, input.type, input.code, input.value);
 				return 1;
 			}
 		}
@@ -269,28 +273,10 @@ static int waitForInput(lua_State *L) {
 		}
 		switch(event.type) {
 			case SDL_KEYDOWN:
-				lua_newtable(L);
-				lua_pushstring(L, "type");
-				lua_pushinteger(L, EV_KEY);
-				lua_settable(L, -3);
-				lua_pushstring(L, "code");
-				lua_pushinteger(L, event.key.keysym.scancode);
-				lua_settable(L, -3);
-				lua_pushstring(L, "value");
-				lua_pushinteger(L, 1);
-				lua_settable(L, -3);
+				createInputEvent(L, EV_KEY, event.key.keysym.scancode, 1);
 				return 1;
 			case SDL_KEYUP:
-				lua_newtable(L);
-				lua_pushstring(L, "type");
-				lua_pushinteger(L, EV_KEY);
-				lua_settable(L, -3);
-				lua_pushstring(L, "code");
-				lua_pushinteger(L, event.key.keysym.scancode);
-				lua_settable(L, -3);
-				lua_pushstring(L, "value");
-				lua_pushinteger(L, 0);
-				lua_settable(L, -3);
+				createInputEvent(L, EV_KEY, event.key.keysym.scancode, 0);
 				return 1;
 			case SDL_QUIT:
 				return luaL_error(L, "application forced to quit");

--- a/input.c
+++ b/input.c
@@ -28,7 +28,6 @@
 #include <linux/input.h>
 #ifdef EMULATE_READER
 #include <SDL.h>
-#define EMU_EV_DEV "emu_event"
 #endif
 
 #include "input.h"

--- a/reader.lua
+++ b/reader.lua
@@ -121,26 +121,11 @@ if ARGV[argidx] then
 	if lfs.attributes(ARGV[argidx], "mode") == "directory" then
 		showFileManager(ARGV[argidx])
 	elseif lfs.attributes(ARGV[argidx], "mode") == "file" then
-		showReader(ARGV[argidx], optarg["p"])
+		showReader(ARGV[argidx])
 	end
 	UIManager:run()
 elseif last_file and lfs.attributes(last_file, "mode") == "file" then
-	showReader(last_file, optarg["p"])
-	UIManager:run()
-else
-	return showusage()
-end
-
-
-if ARGV[optind] then
-	if lfs.attributes(ARGV[optind], "mode") == "directory" then
-		showFileManager(ARGV[optind])
-	elseif lfs.attributes(ARGV[optind], "mode") == "file" then
-		showReader(ARGV[optind], optarg["p"])
-	end
-	UIManager:run()
-elseif last_file and lfs.attributes(last_file, "mode") == "file" then
-	showReader(last_file, optarg["p"])
+	showReader(last_file)
 	UIManager:run()
 else
 	return showusage()


### PR DESCRIPTION
I was trying to add touch simulation to emu mode today, but find out that it is not a easy task to map one single SDL event to multiple fake touch events. So I rewrote the part of the code and use fifofile to pipe all the fake events.

As a side effect, I notice that this implementation also makes automated testing possible, because we can simple write scripts that generate inputs to KPV automatically :)
