### PR TITLE
Get rid of LD_LIBRARY_PATH, LUALIBCOMPAT and package defaults.lua

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ KPDFREADER_CFLAGS=$(CFLAGS) -I$(LUADIR)/src -I$(MUPDFDIR)/
 MUPDFLIBS := $(MUPDFLIBDIR)/libfitz.a
 DJVULIBS := $(DJVUDIR)/build/libdjvu/.libs/libdjvulibre.so \
 			$(LIBDIR)/libdjvulibre.so
+DJVULIB :=	$(LIBDIR)/libdjvulibre.so.21
 DJVULIBDIR := $(DJVUDIR)/build/libdjvu/.libs/
 CRENGINELIBS := $(CRENGINEDIR)/crengine/libcrengine.a \
 			$(CRENGINEDIR)/thirdparty/chmlib/libchmlib.a \
@@ -110,7 +111,6 @@ THIRDPARTYLIBS := $(MUPDFLIBDIR)/libfreetype.a \
 			#$(CRENGINEDIR)/thirdparty/libjpeg/libjpeg.a \
 
 LUALIB := $(LIBDIR)/libluajit-5.1.so.2
-LUALIBCOMPAT := $(LIBDIR)/libluajit-5.1.so
 
 POPENNSLIB := $(POPENNSDIR)/libpopen_noshell.a
 
@@ -135,7 +135,6 @@ kpdfview: kpdfview.o einkfb.o pdf.o k2pdfopt.o blitbuffer.o drawcontext.o input.
 		mupdfimg.o \
 		$(MUPDFLIBS) \
 		$(THIRDPARTYLIBS) \
-		$(LUALIB) \
 		djvu.o \
 		pic.o \
 		pic_jpeg.o \
@@ -257,9 +256,8 @@ else
 	$(MAKE) -C $(LUADIR) BUILDMODE=shared CC="$(HOSTCC)" HOST_CC="$(HOSTCC) -m32" CFLAGS="$(BASE_CFLAGS)" HOST_CFLAGS="$(HOSTCFLAGS)" TARGET_CFLAGS="$(CFLAGS)" CROSS="$(CHOST)-" TARGET_FLAGS="-DLUAJIT_NO_LOG2 -DLUAJIT_NO_EXP2"
 endif
 	test -d $(LIBDIR) || mkdir $(LIBDIR)
-	cp -a $(LUADIR)/src/libluajit.so $(LUALIB)
-	# old linker would not find a libluajit-5.1.so.2
-	cp -a $(LUADIR)/src/libluajit.so $(LUALIBCOMPAT)
+	cp -a $(LUADIR)/src/libluajit.so* $(LUALIB)
+	ln -s libluajit-5.1.so.2 $(LIBDIR)/libluajit-5.1.so
 
 $(POPENNSLIB):
 	$(MAKE) -C $(POPENNSDIR) CC="$(CC)" AR="$(AR)"
@@ -268,7 +266,7 @@ thirdparty: $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) $(DJVULIBS) $(CRENGINELIBS)
 
 INSTALL_DIR=kindlepdfviewer
 
-LUA_FILES=commands.lua crereader.lua dialog.lua djvureader.lua readerchooser.lua filechooser.lua filehistory.lua fileinfo.lua filesearcher.lua font.lua graphics.lua helppage.lua image.lua inputbox.lua keys.lua pdfreader.lua koptconfig.lua koptreader.lua picviewer.lua reader.lua rendertext.lua screen.lua selectmenu.lua settings.lua unireader.lua widget.lua
+LUA_FILES=commands.lua crereader.lua defaults.lua dialog.lua djvureader.lua readerchooser.lua filechooser.lua filehistory.lua fileinfo.lua filesearcher.lua font.lua graphics.lua helppage.lua image.lua inputbox.lua keys.lua pdfreader.lua koptconfig.lua koptreader.lua picviewer.lua reader.lua rendertext.lua screen.lua selectmenu.lua settings.lua unireader.lua widget.lua
 
 customupdate: all
 	# ensure that the binaries were built for ARM
@@ -280,8 +278,7 @@ customupdate: all
 	mkdir -p $(INSTALL_DIR)/{history,screenshots,clipboard,libs}
 	cp -p README.md COPYING kpdfview extr kpdf.sh $(LUA_FILES) $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/data
-	cp -L libs/libdjvulibre.so.21 $(INSTALL_DIR)/libs
-	cp -L $(LUALIB) $(INSTALL_DIR)/libs
+	cp -L $(DJVULIB) $(LUALIB) $(INSTALL_DIR)/libs
 	$(STRIP) --strip-unneeded $(INSTALL_DIR)/libs/*
 	cp -rpL data/*.css $(INSTALL_DIR)/data
 	cp -rpL fonts $(INSTALL_DIR)

--- a/kpdf.sh
+++ b/kpdf.sh
@@ -22,7 +22,7 @@ fi
 killall -stop cvm
 
 # finally call reader
-./reader.lua "$1" 2> /mnt/us/kindlepdfviewer/crash.log || cat /mnt/us/kindlepdfviewer/crash.log
+./reader.lua "$1" 2> crash.log
 
 # unmount system fonts
 if grep /mnt/us/kindlepdfviewer/fonts/host /proc/mounts; then

--- a/kpdf.sh
+++ b/kpdf.sh
@@ -21,7 +21,6 @@ fi
 # stop cvm
 killall -stop cvm
 
-export LD_LIBRARY_PATH=`pwd`/libs
 # finally call reader
 ./reader.lua "$1" 2> /mnt/us/kindlepdfviewer/crash.log || cat /mnt/us/kindlepdfviewer/crash.log
 


### PR DESCRIPTION
1. As we use -Wl,-rpath=$(LIBDIR)/ the RPATH is hardcoded in the kpdfview binary and so there is no need to help the linker find our libraries by setting LD_LIBRARY_PATH at runtime.
2. The file defaults.lua needs to be mentioned in LUA_FILES in the Makefile in order to be packaged by "make customupdate".
3. The problem with the linker not finding libluajit-5.1.so.2 can be fixed without specifying the shared library in the list of objects and static libraries, simply by making a symbolic link. No need to copy a duplicate.
4. Make kpdf.sh simpler by not checking the status of reader.lua and displaying the contents of crash.log (as this wouldn't work anyway)

Tested both on emulator and real Kindle.
