### PR TITLE
Allow anyone to set event notifications.

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -483,21 +483,13 @@ function FileChooser:addAllCommands()
 	self.commands:addGroup("Vol-/+", {Keydef:new(KEY_VPLUS,nil), Keydef:new(KEY_VMINUS,nil)},
 		"decrease/increase sound volume",
 		function(self)
-			if self.filemanager_expert_mode == self.ROOT_MODE then
-				InfoMessage:incrSoundVolume(keydef.keycode == KEY_VPLUS and 1 or -1)
-			else
-				InfoMessage:inform(popup_text, -1, 1, MSG_WARN, voice_text)
-			end
+			InfoMessage:incrSoundVolume(keydef.keycode == KEY_VPLUS and 1 or -1)
 		end
 	)
 	self.commands:addGroup(MOD_SHIFT.."Vol-/+", {Keydef:new(KEY_VPLUS,MOD_SHIFT), Keydef:new(KEY_VMINUS,MOD_SHIFT)},
 		"decrease/increase TTS-engine speed",
 		function(self)
-			if self.filemanager_expert_mode == self.ROOT_MODE then
-				InfoMessage:incrTTSspeed(keydef.keycode == KEY_VPLUS and 1 or -1)
-			else
-				InfoMessage:inform(popup_text, -1, 1, MSG_WARN, voice_text)
-			end
+			InfoMessage:incrTTSspeed(keydef.keycode == KEY_VPLUS and 1 or -1)
 		end
 	)
 	self.commands:add({KEY_F, KEY_AA}, nil, "F, Aa",

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -473,18 +473,11 @@ function FileChooser:addAllCommands()
 			self:changeFileChooserMode()
 		end
 	)
--- NuPogodi, 25.09.12: new functions to tune the way how to inform user about the reader events
-	local popup_text = "Unstable... For experts only! "
-	local voice_text = "This function is still under development and available only for experts and beta testers."
-	self.commands:add(KEY_I, nil, "I",
-		"change the way to inform about events",
+	self.commands:add(KEY_E, nil, "E",
+		"configure event notifications",
 		function(self)
-			if self.filemanager_expert_mode == self.ROOT_MODE then
-				InfoMessage:chooseNotificatonMethods()
-				self.pagedirty = true
-			else
-				InfoMessage:inform(popup_text, -1, 1, MSG_WARN, voice_text)
-			end
+			InfoMessage:chooseNotificatonMethods()
+			self.pagedirty = true
 		end
 	)
 	self.commands:addGroup("Vol-/+", {Keydef:new(KEY_VPLUS,nil), Keydef:new(KEY_VMINUS,nil)},
@@ -507,7 +500,6 @@ function FileChooser:addAllCommands()
 			end
 		end
 	)
------------- end of changes (NuPogodi, 25.09.12) ------------
 	self.commands:add({KEY_F, KEY_AA}, nil, "F, Aa",
 		"change font faces",
 		function(self)

--- a/unireader.lua
+++ b/unireader.lua
@@ -3421,16 +3421,11 @@ function UniReader:addAllCommands()
 			self:redrawCurrentPage()
 		end
 	)
-	self.commands:add(KEY_I, nil, "I",
-		"change the way to inform about events",
+	self.commands:add(KEY_E, nil, "E",
+		"configure event notifications",
 		function(unireader)
-			if FileChooser.filemanager_expert_mode == FileChooser.ROOT_MODE then
-				InfoMessage:chooseNotificatonMethods()
-				self:redrawCurrentPage()
-			else
-				InfoMessage:inform("Unstable... For experts only ", -1, 1, MSG_WARN,
-					"This function is still under development and available only for experts and beta testers.")
-			end
+			InfoMessage:chooseNotificatonMethods()
+			self:redrawCurrentPage()
 		end
 	)
 	self.commands:add(KEY_BACK,MOD_ALT,"Back",


### PR DESCRIPTION
1. Choosing the level of event notifications shouldn't be restricted.
2. It should sit on key E standing for "configure Event notifications" rather than the very lengthy "change the way to Inform about events".

(I would like to use the "I" key for some kind of "Detailed document information" like in CoolReader3. For PDF and DjVu files we can tell a lot of things to the user about the document.)
