### PR TITLE
Make battery logging optional, disabled by default

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -168,7 +168,7 @@ function Commands:new(obj)
 		function()
 			--os.execute("echo 'screensaver in' >> /mnt/us/event_test.txt")
 			if G_charging_mode == false and G_screen_saver_mode == false then
-				logBatteryLevel("SLEEP")
+				if G_battery_logging then logBatteryLevel("SLEEP") end
 				Screen:saveCurrentBB()
 				InfoMessage:inform("Going into screensaver... ", nil, 0, MSG_AUX)
 				Screen.kpv_rotation_mode = Screen.cur_rotation_mode
@@ -184,7 +184,7 @@ function Commands:new(obj)
 		function()
 			--os.execute("echo 'screensaver out' >> /mnt/us/event_test.txt")
 			if G_screen_saver_mode == true and G_charging_mode == false then
-				logBatteryLevel("WAKEUP")
+				if G_battery_logging then logBatteryLevel("WAKEUP") end
 				util.usleep(1500000)
 				os.execute("killall -stop cvm")
 				fb:setOrientation(Screen.kpv_rotation_mode)
@@ -199,7 +199,7 @@ function Commands:new(obj)
 		function()
 			--os.execute("echo 'usb in' >> /mnt/us/event_test.txt")
 			if G_charging_mode == false and G_screen_saver_mode == false then
-				logBatteryLevel("USB PLUG")
+				if G_battery_logging then logBatteryLevel("USB PLUG") end
 				Screen:saveCurrentBB()
 				Screen.kpv_rotation_mode = Screen.cur_rotation_mode
 				fb:setOrientation(Screen.native_rotation_mode)
@@ -220,7 +220,7 @@ function Commands:new(obj)
 				fb:setOrientation(Screen.kpv_rotation_mode)
 				Screen:restoreFromSavedBB()
 				fb:refresh(0)
-				logBatteryLevel("USB UNPLUG")
+				if G_battery_logging then logBatteryLevel("USB UNPLUG") end
 			end
 			FileChooser:setPath(FileChooser.path)
 			FileChooser.pagedirty = true
@@ -231,7 +231,7 @@ function Commands:new(obj)
 	-- I suggest one should probably change the hotkey to, say, Alt+Space
 	obj:add(KEY_P, MOD_SHIFT, "P", "make screenshot",
 		function()
-			logBatteryLevel("SCREENSHOT")
+			if G_battery_logging then logBatteryLevel("SCREENSHOT") end
 			Screen:screenshot()
 		end
 	)

--- a/defaults.lua
+++ b/defaults.lua
@@ -36,6 +36,9 @@ DCACHE_MAX_TTL = 20 -- time to live
 -- renderer cache size
 DCACHE_DOCUMENT_SIZE = 1024*1024*8 -- FIXME random, needs testing
 
+-- default value for battery level logging
+DBATTERY_LOGGING = false
+
 -- background colour: 8 = gray, 0 = white, 15 = black
 DBACKGROUND_COLOR = 8
 

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -597,7 +597,7 @@ function FileChooser:addAllCommands()
 		"toggle battery level logging",
 		function(self)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), 1000, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), nil, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
 			self.pagedirty = true
 		end

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -593,6 +593,15 @@ function FileChooser:addAllCommands()
 			self.pagedirty = true
 		end
 	)
+	self.commands:add(KEY_DOT, MOD_ALT, ".",
+		"toggle battery level logging",
+		function(self)
+			G_battery_logging = not G_battery_logging
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), 1000, 1, MSG_AUX)
+			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
+			self.pagedirty = true
+		end
+	)
 	self.commands:add(KEY_B, MOD_SHIFT, "B",
 		"show content of 'clipboard'",
 		function(self)

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -426,7 +426,7 @@ function FileChooser:addAllCommands()
 					self:deleteFileAtPosition(pos)
 				else
 					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM, confirm)
-					if self:ReturnKey() == KEY_Y then self:deleteFileAtPosition(pos) end
+					if ReturnKey() == KEY_Y then self:deleteFileAtPosition(pos) end
 				end
 			elseif self.dirs[pos] == ".." then 
 				warningUnsupportedFunction()
@@ -435,7 +435,7 @@ function FileChooser:addAllCommands()
 					self:deleteFolderAtPosition(pos)
 				else
 					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM, confirm)
-					if self:ReturnKey() == KEY_Y then self:deleteFolderAtPosition(pos) end
+					if ReturnKey() == KEY_Y then self:deleteFolderAtPosition(pos) end
 				end
 			end
 			self.pagedirty = true
@@ -549,10 +549,10 @@ function FileChooser:addAllCommands()
 			-- TODO (NuPogodi, 27.09.12): overwrite?
 			local file = self:FullFileName()
 			if file then
-				os.execute("cp "..self:InQuotes(file).." "..self.clipboard)
+				os.execute("cp "..InQuotes(file).." "..self.clipboard)
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
-				os.execute("cp "..self:InQuotes(DocToHistory(file)).." "
-					..self:InQuotes(DocToHistory(self.clipboard.."/"..fn)) )
+				os.execute("cp "..InQuotes(DocToHistory(file)).." "
+					..InQuotes(DocToHistory(self.clipboard.."/"..fn)) )
 				InfoMessage:inform("File copied to clipboard ", 1000, 1, MSG_WARN,
 					"The file has been copied to clipboard.")
 			end
@@ -649,7 +649,7 @@ function FileChooser:FullFileName()
 end
 
 -- returns the keycode of released key
-function FileChooser:ReturnKey()
+function ReturnKey()
 	while true do
 		ev = input.saveWaitForEvent()
 		ev.code = adjustKeyEvents(ev)
@@ -660,7 +660,7 @@ function FileChooser:ReturnKey()
 	return ev.code
 end
 
-function FileChooser:InQuotes(text)
+function InQuotes(text)
 	return "\""..text.."\""
 end
 

--- a/filehistory.lua
+++ b/filehistory.lua
@@ -254,7 +254,7 @@ function FileHistory:addAllCommands()
 			else
 				InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM,
 					"Please, press key Y to delete the book history")
-				if FileChooser:ReturnKey() == KEY_Y then
+				if ReturnKey() == KEY_Y then
 					os.remove(DocToHistory(file_to_del))
 					self:init()
 					self:setSearchResult(self.keywords)

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -261,7 +261,7 @@ function FileSearcher:addAllCommands()
 			else
 				InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM,
 					"Press key Y to confirm deleting")
-				if FileChooser:ReturnKey() == KEY_Y then
+				if ReturnKey() == KEY_Y then
 					self:deleteFoundFile(file_to_del)
 				end
 			self.pagedirty = true

--- a/reader.lua
+++ b/reader.lua
@@ -27,6 +27,7 @@ require "screen"
 require "commands"
 require "dialog"
 require "readerchooser"
+require "defaults"
 
 function openFile(filename)
 	local file_type = string.lower(string.match(filename, ".+%.([^.]+)"))
@@ -137,6 +138,12 @@ end
 -- set up the mode to manage files
 FileChooser.filemanager_expert_mode = G_reader_settings:readSetting("filemanager_expert_mode") or 1
 InfoMessage:initInfoMessageSettings()
+local tmp = G_reader_settings:readSetting("G_battery_logging")
+if tmp ~= nil then
+	G_battery_logging = tmp
+else
+	G_battery_logging = DBATTERY_LOGGING
+end
 
 -- initialize global settings shared among all readers
 UniReader:initGlobalSettings(G_reader_settings)

--- a/unireader.lua
+++ b/unireader.lua
@@ -2623,7 +2623,7 @@ function UniReader:addAllCommands()
 		"toggle battery level logging",
 		function(unireader)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), 1000, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), nil, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
 			self:redrawCurrentPage()
 		end)

--- a/unireader.lua
+++ b/unireader.lua
@@ -2619,6 +2619,14 @@ function UniReader:addAllCommands()
 			HelpPage:show(0, G_height, unireader.commands)
 			unireader:redrawCurrentPage()
 		end)
+	self.commands:add(KEY_DOT,MOD_ALT,".",
+		"toggle battery level logging",
+		function(unireader)
+			G_battery_logging = not G_battery_logging
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), 1000, 1, MSG_AUX)
+			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
+			self:redrawCurrentPage()
+		end)
 	self.commands:add(KEY_T,nil,"T",
 		"show table of content (TOC)",
 		function(unireader)


### PR DESCRIPTION
The key that toggles the battery logging is ALT+KEY_DOT and it works both in the readers and filechooser.
