### PR TITLE
feature: add bbox support in koptreader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,7 @@ HOSTCXX:=g++
 HOSTAR:=ar
 
 # Base CFLAGS, without arch. We'll need it for luajit, because its Makefiles do some tricky stuff to differentiate HOST/TARGET
-BASE_CFLAGS:=-O2 -ffast-math -pipe
-KOPT_CFLAGS:=-O3 -ffast-math -fno-finite-math-only -pipe
+BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 # Use this for debugging:
 #BASE_CFLAGS:=-O0 -g
 # Misc GCC tricks to ensure backward compatibility with the K2, even when using a fairly recent TC (Linaro/MG).
@@ -269,7 +268,7 @@ $(POPENNSLIB):
 	$(MAKE) -C $(POPENNSDIR) CC="$(CC)" AR="$(AR)"
 
 $(K2PDFOPTLIB):
-	$(MAKE) -C $(K2PDFOPTLIBDIR) BUILDMODE=shared CC="$(CC)" CFLAGS="$(KOPT_CFLAGS)" AR="$(AR)" all
+	$(MAKE) -C $(K2PDFOPTLIBDIR) BUILDMODE=shared CC="$(CC)" CFLAGS="$(CFLAGS) -O3" AR="$(AR)" all
 	test -d $(LIBDIR) || mkdir $(LIBDIR)
 	cp -a $(K2PDFOPTLIBDIR)/libk2pdfopt.so* $(LIBDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ HOSTCXX:=g++
 HOSTAR:=ar
 
 # Base CFLAGS, without arch. We'll need it for luajit, because its Makefiles do some tricky stuff to differentiate HOST/TARGET
-BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
-KOPT_CFLAGS:=-O3 -ffast-math -pipe -fomit-frame-pointer
+BASE_CFLAGS:=-O2 -ffast-math -pipe
+KOPT_CFLAGS:=-O3 -ffast-math -pipe
 # Use this for debugging:
 #BASE_CFLAGS:=-O0 -g
 # Misc GCC tricks to ensure backward compatibility with the K2, even when using a fairly recent TC (Linaro/MG).

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ LUALIB := $(LIBDIR)/libluajit-5.1.so.2
 
 POPENNSLIB := $(POPENNSDIR)/libpopen_noshell.a
 
-K2PDFOPTLIB := $(LIBDIR)/libk2pdfopt.so
+K2PDFOPTLIB := $(LIBDIR)/libk2pdfopt.so.1
 
 all: kpdfview extr
 
@@ -289,7 +289,7 @@ customupdate: all
 	mkdir -p $(INSTALL_DIR)/{history,screenshots,clipboard,libs}
 	cp -p README.md COPYING kpdfview extr kpdf.sh $(LUA_FILES) $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/data
-	cp -L $(DJVULIB) $(LUALIB) $(INSTALL_DIR)/libs
+	cp -L $(DJVULIB) $(LUALIB) $(K2PDFOPTLIB) $(INSTALL_DIR)/libs
 	$(STRIP) --strip-unneeded $(INSTALL_DIR)/libs/*
 	cp -rpL data/*.css $(INSTALL_DIR)/data
 	cp -rpL fonts $(INSTALL_DIR)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ HOSTAR:=ar
 
 # Base CFLAGS, without arch. We'll need it for luajit, because its Makefiles do some tricky stuff to differentiate HOST/TARGET
 BASE_CFLAGS:=-O2 -ffast-math -pipe
-KOPT_CFLAGS:=-O3 -ffast-math -pipe
+KOPT_CFLAGS:=-O3 -ffast-math -fno-finite-math-only -pipe
 # Use this for debugging:
 #BASE_CFLAGS:=-O0 -g
 # Misc GCC tricks to ensure backward compatibility with the K2, even when using a fairly recent TC (Linaro/MG).

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ LUALIB := $(LIBDIR)/libluajit-5.1.so.2
 
 POPENNSLIB := $(POPENNSDIR)/libpopen_noshell.a
 
-K2PDFOPTLIB := $(K2PDFOPTLIBDIR)/libk2pdfopt.a
+K2PDFOPTLIB := $(LIBDIR)/libk2pdfopt.so
 
 all: kpdfview extr
 
@@ -137,7 +137,6 @@ kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o koptcontext.o inp
 		ft.o \
 		lfs.o \
 		mupdfimg.o \
-		$(K2PDFOPTLIB) \
 		$(MUPDFLIBS) \
 		$(THIRDPARTYLIBS) \
 		djvu.o \
@@ -149,7 +148,7 @@ kpdfview: kpdfview.o einkfb.o pdf.o blitbuffer.o drawcontext.o koptcontext.o inp
 		$(LDFLAGS) \
 		-Wl,-rpath=$(LIBDIR)/ \
 		-o $@ \
-		-lm -ldl -lpthread -ldjvulibre -ljpeg -lluajit-5.1 -L$(MUPDFLIBDIR) -L$(LIBDIR)\
+		-lm -ldl -lpthread -lk2pdfopt -ldjvulibre -ljpeg -lluajit-5.1 -L$(MUPDFLIBDIR) -L$(LIBDIR)\
 		$(EMU_LDFLAGS) \
 		$(DYNAMICLIBSTDCPP)
 
@@ -269,7 +268,9 @@ $(POPENNSLIB):
 	$(MAKE) -C $(POPENNSDIR) CC="$(CC)" AR="$(AR)"
 
 $(K2PDFOPTLIB):
-	$(MAKE) -C $(K2PDFOPTLIBDIR) BUILDMODE=static CC="$(CC)" CFLAGS="$(CFLAGS) -I../$(DJVUDIR)/ -I../$(MUPDFDIR)/" AR="$(AR)"
+	$(MAKE) -C $(K2PDFOPTLIBDIR) BUILDMODE=shared CC="$(CC)" CFLAGS="$(CFLAGS)" AR="$(AR)" all
+	test -d $(LIBDIR) || mkdir $(LIBDIR)
+	cp -a $(K2PDFOPTLIBDIR)/libk2pdfopt.so* $(LIBDIR)
 
 thirdparty: $(MUPDFLIBS) $(THIRDPARTYLIBS) $(LUALIB) $(DJVULIBS) $(CRENGINELIBS) $(POPENNSLIB) $(K2PDFOPTLIB)
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ HOSTAR:=ar
 
 # Base CFLAGS, without arch. We'll need it for luajit, because its Makefiles do some tricky stuff to differentiate HOST/TARGET
 BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
+KOPT_CFLAGS:=-O3 -ffast-math -pipe -fomit-frame-pointer
 # Use this for debugging:
 #BASE_CFLAGS:=-O0 -g
 # Misc GCC tricks to ensure backward compatibility with the K2, even when using a fairly recent TC (Linaro/MG).
@@ -268,7 +269,7 @@ $(POPENNSLIB):
 	$(MAKE) -C $(POPENNSDIR) CC="$(CC)" AR="$(AR)"
 
 $(K2PDFOPTLIB):
-	$(MAKE) -C $(K2PDFOPTLIBDIR) BUILDMODE=shared CC="$(CC)" CFLAGS="$(CFLAGS)" AR="$(AR)" all
+	$(MAKE) -C $(K2PDFOPTLIBDIR) BUILDMODE=shared CC="$(CC)" CFLAGS="$(KOPT_CFLAGS)" AR="$(AR)" all
 	test -d $(LIBDIR) || mkdir $(LIBDIR)
 	cp -a $(K2PDFOPTLIBDIR)/libk2pdfopt.so* $(LIBDIR)
 

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -144,7 +144,7 @@ KOPTOptions =  {
 	current_item=3,
 	text_dirty=true,
 	marker_dirty={true, true, true, true, true},
-	value={0.2, 0.4, 1.0, 1.8, 2.6},
+	value={2.0, 1.5, 1.0, 0.5, 0.2},
 	show = true,
 	draw_index = nil,},
 	{

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -17,8 +17,8 @@ KOPTOptions =  {
 	draw_index = nil,},
 	{
 	name="text_wrap",
-	option_text="Text Wrap",
-	items_text={"enable","disable"},
+	option_text="Reflow",
+	items_text={"on","off"},
 	default_item=1,
 	current_item=1,
 	text_dirty=true,
@@ -46,17 +46,17 @@ KOPTOptions =  {
 	text_dirty=true,
 	marker_dirty={true, true},
 	value={1, 0},
-	show = true,
+	show = false,
 	draw_index = nil,},
 	{
 	name="defect_size",
 	option_text="Defect Size",
 	items_text={"small","medium","large"},
-	default_item=1,
-	current_item=1,
+	default_item=2,
+	current_item=2,
 	text_dirty=true,
 	marker_dirty={true, true, true},
-	value={1.0, 2.0, 5.0},
+	value={0.5, 1.0, 2.0},
 	show = true,
 	draw_index = nil,},
 	{
@@ -68,7 +68,7 @@ KOPTOptions =  {
 	text_dirty=true,
 	marker_dirty={true, true, true},
 	value={0.02, 0.06, 0.10},
-	show = false,
+	show = true,
 	draw_index = nil,},
 	{
 	name="line_spacing",
@@ -79,23 +79,23 @@ KOPTOptions =  {
 	text_dirty=true,
 	marker_dirty={true, true, true},
 	value={1.0, 1.2, 1.4},
-	show = false,
+	show = true,
 	draw_index = nil,},
 	{
 	name="word_spacing",
 	option_text="Word Spacing",
-	items_text={"smaller","small","medium","large"},
-	default_item=3,
-	current_item=3,
+	items_text={"small","medium","large"},
+	default_item=2,
+	current_item=2,
 	text_dirty=true,
 	marker_dirty={true, true, true, true},
-	value={0.1, 0.2, 0.375, 0.5},
+	value={0.1, 0.375, 0.5},
 	show = true,
 	draw_index = nil,},
 	{
 	name="quality",
 	option_text="Render Quality",
-	items_text={"performance","balanced","quality"},
+	items_text={"low","medium","high"},
 	default_item=3,
 	current_item=3,
 	text_dirty=true,
@@ -106,18 +106,18 @@ KOPTOptions =  {
 	{
 	name="auto_straighten",
 	option_text="Auto Straighten",
-	items_text={"default","0","5","10"},
+	items_text={"0","5","10"},
 	default_item=1,
 	current_item=1,
 	text_dirty=true,
-	marker_dirty={true, true, true, true},
-	value={0, 0, 5, 10},
+	marker_dirty={true, true, true},
+	value={0, 5, 10},
 	show = true,
 	draw_index = nil,},
 	{
 	name="justification",
 	option_text="Justification",
-	items_text={"default","left","center","right","full"},
+	items_text={"auto","left","center","right","full"},
 	default_item=1,
 	current_item=1,
 	text_dirty=true,
@@ -128,12 +128,12 @@ KOPTOptions =  {
 	{
 	name="max_columns",
 	option_text="Columns",
-	items_text={"auto","1","2","3","4"},
+	items_text={"1","2","3","4"},
 	default_item=1,
 	current_item=1,
 	text_dirty=true,
-	marker_dirty={true, true, true, true, true},
-	value={2,1,2,3,4},
+	marker_dirty={true, true, true, true},
+	value={1,2,3,4},
 	show = true,
 	draw_index = nil,},
 	{
@@ -167,7 +167,7 @@ KOPTConfig = {
 	MARGIN_BOTTOM = 25,  -- window bottom margin
 	OPTION_PADDING_T = 60, -- option top padding
 	OPTION_PADDING_H = 70, -- option horizontal padding
-	OPTION_SPACING_V = 35,	-- options vertical spacing
+	OPTION_SPACING_V = 30,	-- options vertical spacing
 	NAME_ALIGN_RIGHT = 0.28, -- align name right to the window width
 	ITEM_ALIGN_LEFT = 0.30,	-- align item left to the window width
 	ITEM_SPACING_H = 10,   -- items horisontal spacing
@@ -287,8 +287,8 @@ function KOPTConfig:makeDefault(configurable)
 					KOPTOptions[i].current_item = index
 				end
 			end
-		end
-	end
+		end -- for index
+	end -- for i
 end
 
 function KOPTConfig:reconfigure(configurable)

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -29,7 +29,7 @@ KOPTOptions =  {
 	{
 	name="trim_page",
 	option_text="Trim Page",
-	items_text={"enable","disable"},
+	items_text={"auto","manual"},
 	default_item=1,
 	current_item=1,
 	text_dirty=true,

--- a/koptcontext.c
+++ b/koptcontext.c
@@ -19,30 +19,33 @@
 #include "koptcontext.h"
 
 static int newKOPTContext(lua_State *L) {
-	int trim = luaL_optint(L, 1, 1);
-	int wrap = luaL_optint(L, 2, 1);
-	int indent = luaL_optint(L, 3, 1);
-	int rotate = luaL_optint(L, 4, 0);
-	int columns = luaL_optint(L, 5, 2);
-	int offset_x = luaL_optint(L, 6, 0);
-	int offset_y = luaL_optint(L, 7, 0);
-	int dev_width = luaL_optint(L, 8, 600);
-	int dev_height = luaL_optint(L, 9, 800);
-	int page_width = luaL_optint(L, 10, 600);
-	int page_height = luaL_optint(L, 11, 800);
-	int straighten = luaL_optint(L, 12, 0);
-	int justification = luaL_optint(L, 13, -1);
+	int trim = 1;
+	int wrap = 1;
+	int indent = 1;
+	int rotate = 0;
+	int columns = 2;
+	int offset_x = 0;
+	int offset_y = 0;
+	int dev_width = 600;
+	int dev_height = 800;
+	int page_width = 600;
+	int page_height = 800;
+	int straighten = 0;
+	int justification = -1;
+	int read_max_width = 3000;
+	int read_max_height = 4000;
 
-	double zoom = luaL_optnumber(L, 14, (double) 1.0);
-	double margin = luaL_optnumber(L, 15, (double) 0.06);
-	double quality = luaL_optnumber(L, 16, (double) 1.0);
-	double contrast = luaL_optnumber(L, 17, (double) 1.0);
-	double defect_size = luaL_optnumber(L, 18, (double) 1.0);
-	double line_spacing = luaL_optnumber(L, 19, (double) 1.2);
-	double word_spacing = luaL_optnumber(L, 20, (double) 1.375);
+	double zoom = 1.0;
+	double margin = 0.06;
+	double quality = 1.0;
+	double contrast = 1.0;
+	double defect_size = 1.0;
+	double line_spacing = 1.2;
+	double word_spacing = 1.375;
+	double shrink_factor = 0.9;
 
 	uint8_t *data = NULL;
-	fz_rect bbox = {0, 0, 0, 0};
+	BBox bbox = {0, 0, 0, 0};
 
 	KOPTContext *kc = (KOPTContext*) lua_newuserdata(L, sizeof(KOPTContext));
 
@@ -59,6 +62,8 @@ static int newKOPTContext(lua_State *L) {
 	kc->page_height = page_height;
 	kc->straighten = straighten;
 	kc->justification = justification;
+	kc->read_max_width = read_max_width;
+	kc->read_max_height = read_max_height;
 
 	kc->zoom = zoom;
 	kc->margin = margin;
@@ -67,6 +72,7 @@ static int newKOPTContext(lua_State *L) {
 	kc->defect_size = defect_size;
 	kc->line_spacing = line_spacing;
 	kc->word_spacing = word_spacing;
+	kc->shrink_factor = shrink_factor;
 
 	kc->data = data;
 	kc->bbox = bbox;

--- a/koptcontext.c
+++ b/koptcontext.c
@@ -42,6 +42,7 @@ static int newKOPTContext(lua_State *L) {
 	double word_spacing = luaL_optnumber(L, 20, (double) 1.375);
 
 	uint8_t *data = NULL;
+	fz_rect bbox = {0, 0, 0, 0};
 
 	KOPTContext *kc = (KOPTContext*) lua_newuserdata(L, sizeof(KOPTContext));
 
@@ -68,6 +69,7 @@ static int newKOPTContext(lua_State *L) {
 	kc->word_spacing = word_spacing;
 
 	kc->data = data;
+	kc->bbox = bbox;
 
 	luaL_getmetatable(L, "koptcontext");
 	lua_setmetatable(L, -2);
@@ -75,10 +77,25 @@ static int newKOPTContext(lua_State *L) {
 	return 1;
 }
 
+static int kcSetBBox(lua_State *L) {
+	KOPTContext *kc = (KOPTContext*) luaL_checkudata(L, 1, "koptcontext");
+	kc->bbox.x0 = luaL_checknumber(L, 2);
+	kc->bbox.y0 = luaL_checknumber(L, 3);
+	kc->bbox.x1 = luaL_checknumber(L, 4);
+	kc->bbox.y1 = luaL_checknumber(L, 5);
+	return 0;
+}
+
 static int kcSetTrim(lua_State *L) {
 	KOPTContext *kc = (KOPTContext*) luaL_checkudata(L, 1, "koptcontext");
 	kc->trim = luaL_checkint(L, 2);
 	return 0;
+}
+
+static int kcGetTrim(lua_State *L) {
+	KOPTContext *kc = (KOPTContext*) luaL_checkudata(L, 1, "koptcontext");
+	lua_pushinteger(L, kc->trim);
+	return 1;
 }
 
 static int kcSetWrap(lua_State *L) {
@@ -194,7 +211,9 @@ static int kcSetWordSpacing(lua_State *L) {
 }
 
 static const struct luaL_Reg koptcontext_meth[] = {
+	{"setBBox", kcSetBBox},
 	{"setTrim", kcSetTrim},
+	{"getTrim", kcGetTrim},
 	{"setWrap", kcSetWrap},
 	{"setIndent", kcSetIndent},
 	{"setRotate", kcSetRotate},

--- a/pdf.c
+++ b/pdf.c
@@ -606,10 +606,6 @@ static int reflowPage(lua_State *L) {
 	fz_run_page(page->doc->xref, page->page, dev, ctm, NULL);
 	fz_free_device(dev);
 
-	if (kctx->contrast >= 0.0) {
-		fz_gamma_pixmap(page->doc->context, pix, kctx->contrast);
-	}
-
 	src = &_src;
 	bmp_init(src);
 


### PR DESCRIPTION
Reflow can be configured to use bbox which could remove side comments and defects in the margin and get much better reflowed page for some documents. Currently the bbox can only be set in PDFReader or DJVUReader reader. But eventually there will be bbox setting routines in KOPTReader.

Thirdparty should be cleaned and refetched and remade to get this feature in operation.
