### PR TITLE
Fixes bugs with viewport mode reported by tigran123 in #555

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1357,7 +1357,7 @@ function UniReader:setzoom(page, preCache)
 		self.offset_y = -1 * y0 * self.globalzoom + margin
 		self.pan_x = self.offset_x
 		self.pan_y = self.offset_y
-		self.pan_x1 = -1 * x1 * self.globalzoom - margin + G_width
+		self.pan_x1 = -1 * x1 * self.globalzoom - margin + G_width  -- sets pan_x1 to left edge of the right column
 		self.pan_y1 = -1 * y1 * self.globalzoom - margin + G_height
 		self.pan_by_page = self.globalzoom_mode -- store for later and enable pan_by_page
 		self.globalzoom_mode = self.ZOOM_BY_VALUE -- enable pan mode
@@ -1738,7 +1738,8 @@ function UniReader:twoColNextView()
 	-- can't go down anymore
 	else
 		if self.rtl_mode_enable then -- rtl_mode enabled
-		  if self.offset_x <= self.pan_x then
+			-- can go left?
+		  if self.offset_x + 0.01 < self.pan_x then
 				self.offset_x = self.offset_x + x
 				self.offset_y = self.pan_y
 				self.show_overlap = 0
@@ -1753,7 +1754,7 @@ function UniReader:twoColNextView()
 
 		else -- rtl_mode disabled
 			-- can go right?
-			if self.offset_x > self.pan_x - x then
+			if self.offset_x - 0.01 > self.pan_x1 then
 				self.offset_x = self.offset_x - x
 				self.offset_y = self.pan_y
 				self.show_overlap = 0
@@ -1788,7 +1789,7 @@ function UniReader:twoColPrevView()
 	else 	
 		if self.rtl_mode_enable then -- rtl_mode enabled
 			-- can go right?
-		  if self.offset_x > self.pan_x then
+		  if self.offset_x - 0.01 > self.pan_x1 then
 				self.offset_x = self.offset_x - x
 				self.offset_y = self.min_offset_y
 				self.show_overlap = 0
@@ -1806,7 +1807,7 @@ function UniReader:twoColPrevView()
 		  end
 		else -- rtl_mode disabled
 			-- can go left?
-		  if self.offset_x < self.pan_x then
+		  if self.offset_x + 0.01 < self.pan_x then
 				self.offset_x = self.offset_x + x
 				self.offset_y = self.pan_y1
 				self.show_overlap = 0


### PR DESCRIPTION
This should fix the bug reported by tigran123 in #555. As I thought, the cause was rounding errors. Don't you just love floats? Please test and report.

I'd also like to fix the bug with vertical space too, because the cause is probably the same (rounding error, just in different place). If you can, please provide the file and details.

@dpavlin I said earlier that I don't use pan_x1. It turned out that I do. Formulas can be written without using it, but I think that using it makes them simpler. So, pan_x is set to the left edge of the left column, and pan_x1 is set to the left edge of the right column.
