### PR TITLE
Info_timeout in emulator and defaults.lua clean-up

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -23,11 +23,8 @@ DSHIFT_Y = 50
 -- step to change zoom manually, default = 16%
 DSTEP_MANUAL_ZOOM = 16
 DPAN_BY_PAGE = false -- using shift_[xy] or width/height
-DPAN_X = 0 -- top-left offset of page when pan activated
-DPAN_Y = 0
 DPAN_MARGIN = 5 -- horizontal margin for two-column zoom (in pixels)
 DPAN_OVERLAP_VERTICAL = 30
-DSHOW_OVERLAP = 0
 
 -- tile cache configuration:
 DCACHE_MAX_MEMSIZE = 1024*1024*5 -- 5MB tile cache
@@ -42,8 +39,9 @@ DBATTERY_LOGGING = false
 -- background colour: 8 = gray, 0 = white, 15 = black
 DBACKGROUND_COLOR = 8
 
--- page mode
-DPAGE_MODE_ENABLE = false
+-- timeout for info messages in ms
+DINFO_TIMEOUT_FAST=nil
+DINFO_TIMEOUT_SLOW=1000
 
 -- toggle defaults
 DUNIREADER_SHOW_OVERLAP_ENABLE = true

--- a/dialog.lua
+++ b/dialog.lua
@@ -136,6 +136,9 @@ function InfoMessage:inform(text, msec, refresh_mode, message_importance, altern
 	end
 	if not popup then return end -- to avoid drawing popup window
 	self.ImageFile = self.Images[message_importance] -- select proper image for window
+	if util.isEmulated()==1 then
+		msec = DINFO_TIMEOUT_SLOW
+	end
 	if not msec or msec == 0 then
 		InfoMessage:show(text, refresh_mode)
 	else

--- a/unireader.lua
+++ b/unireader.lua
@@ -62,13 +62,13 @@ UniReader = {
 	-- step to change zoom manually, default = 16%
 	step_manual_zoom = DSTEP_MANUAL_ZOOM,
 	pan_by_page = DPAN_BY_PAGE, -- using shift_[xy] or width/height
-	pan_x = DPAN_X, -- top-left offset of page when pan activated
-	pan_y = DPAN_Y,
+	pan_x = 0, -- top-left offset of page when pan activated
+	pan_y = 0,
 	pan_x1 = 0, -- bottom-right offset of page when pan activated
 	pan_y1 = 0,
 	pan_margin = DPAN_MARGIN, -- horizontal margin for two-column zoom (in pixels)
 	pan_overlap_vertical = DPAN_OVERLAP_VERTICAL,
-	show_overlap = DSHOW_OVERLAP,
+	show_overlap = 0,
 	show_overlap_enable,
 	show_links_enable,
 	comics_mode_enable,
@@ -138,7 +138,7 @@ end
 
 function UniReader:init()
 	-- initialize commands
-	InfoMessage:inform("Registering fonts...", nil, 1, MSG_AUX)
+	InfoMessage:inform("Registering fonts...", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 	self:addAllCommands()
 end
 
@@ -395,7 +395,7 @@ end
 function UniReader:startHighLightMode()
 	local t = self:getText(self.pageno)
 	if not t or #t == 0 then
-		InfoMessage:inform("No text available ", 1000, 1, MSG_WARN);
+		InfoMessage:inform("No text available ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN);
 		return nil
 	end
 
@@ -406,7 +406,7 @@ function UniReader:startHighLightMode()
 			end
 		end
 
-		InfoMessage:inform("No visible text ", 1000, 1, MSG_WARN);
+		InfoMessage:inform("No visible text ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN);
 		Debug("_findFirstWordInView none found in", t)
 
 		return nil
@@ -1831,7 +1831,7 @@ end
 function UniReader:modifyGamma(factor)
 	Debug("modifyGamma, gamma=", self.globalgamma, " factor=", factor)
 	self.globalgamma = self.globalgamma * factor;
-	InfoMessage:inform(string.format("New gamma is %.2f", self.globalgamma), nil, 1, MSG_AUX)
+	InfoMessage:inform(string.format("New gamma is %.2f", self.globalgamma), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 	self:redrawCurrentPage()
 end
 
@@ -2049,7 +2049,7 @@ function UniReader:showToc()
 	end
 
 	if #self.toc == 0 then
-		return InfoMessage:inform("No Table of Contents ", 1500, 1, MSG_WARN)
+		return InfoMessage:inform("No Table of Contents ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	end
 
 	local toc_curitem = self:findTOCpos()
@@ -2067,7 +2067,7 @@ function UniReader:showToc()
 			local toc_entry = self.toc[self.toc_curidx_to_x[ret_code]]
 			local pagenum = toc_entry.page
 			if pagenum < 1 or pagenum > self.doc:getPages() then
-				InfoMessage:inform("External links unsupported ", 1500, 1, MSG_WARN)
+				InfoMessage:inform("External links unsupported ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				toc_curitem = ret_code
 			else
 				return self:gotoTocEntry(toc_entry)
@@ -2106,7 +2106,7 @@ function UniReader:showJumpHist()
 	end
 
 	if #menu_items == 0 then
-		InfoMessage:inform("No jump history found ", 2000, 1, MSG_WARN)
+		InfoMessage:inform("No jump history found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	else
 		-- if cur points to head, draw entry for current page
 		if self.jump_history.cur > #self.jump_history then
@@ -2143,7 +2143,7 @@ function UniReader:showBookMarks()
 			"p."..v.page.." "..v.notes.." @ "..v.datetime)
 	end
 	if #menu_items == 0 then
-		return InfoMessage:inform("No bookmarks found ", 1500, 1, MSG_WARN)
+		return InfoMessage:inform("No bookmarks found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	end
 	while true do
 		bm_menu = SelectMenu:new{
@@ -2206,7 +2206,7 @@ function UniReader:showHighLight()
 	end
 
 	if #menu_items == 0 then
-		return InfoMessage:inform("No HighLights found ", 1000, 1, MSG_WARN)
+		return InfoMessage:inform("No HighLights found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	end
 
 	while true do
@@ -2313,14 +2313,14 @@ function UniReader:searchHighLight(search)
 
 	self:goto(self.pageno) -- show highlights, remove input
 	if found > 0 then
-		InfoMessage:inform( found.." hits '"..search.."' page "..self.pageno, 2000, 1, MSG_WARN)
+		InfoMessage:inform( found.." hits '"..search.."' page "..self.pageno, DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 		self.last_search = {
 			pageno = self.pageno,
 			search = search,
 			hits = found,
 		}
 	else
-		InfoMessage:inform( "'"..search.."' not found in document ", 2000, 1, MSG_WARN)
+		InfoMessage:inform( "'"..search.."' not found in document ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	end
 
 	self.highlight = old_highlight -- will not remove search highlights until page refresh
@@ -2509,7 +2509,7 @@ function UniReader:gotoPrevNextTocEntry(direction)
 		self:fillToc()
 	end
 	if #self.toc == 0 then
-		return InfoMessage:inform("No Table of Contents ", 1500, 1, MSG_WARN)
+		return InfoMessage:inform("No Table of Contents ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	end
 
 	local numpages, last_toc_page, penul_toc_page = self.doc:getPages(), 1, 1
@@ -2583,7 +2583,7 @@ function UniReader:addAllCommands()
 		function(unireader,keydef)
 			local is_zoom_out = (keydef.keycode == KEY_PGBCK or keydef.keycode == KEY_LPGBCK)
 			local new_zoom = unireader.globalzoom_orig * (1 + (is_zoom_out and -1 or 1)*unireader.step_manual_zoom/100)
-			InfoMessage:inform(string.format("New zoom is %.2f ", new_zoom), nil, 1, MSG_WARN)
+			InfoMessage:inform(string.format("New zoom is %.2f ", new_zoom), DINFO_TIMEOUT_FAST, 1, MSG_WARN)
 			unireader:setGlobalZoom(new_zoom)
 		end)
 	-- NuPogodi, 03.09.12: make zoom step user-configurable
@@ -2595,15 +2595,15 @@ function UniReader:addAllCommands()
 			if keydef.keycode == KEY_PGFWD or keydef.keycode == KEY_LPGFWD then
 				unireader.step_manual_zoom = unireader.step_manual_zoom * 2
 				self.settings:saveSetting("step_manual_zoom", self.step_manual_zoom)
-				InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			else
 				local minstep = 1
 				if unireader.step_manual_zoom > 2*minstep then
 					unireader.step_manual_zoom = unireader.step_manual_zoom / 2
 					self.settings:saveSetting("step_manual_zoom", self.step_manual_zoom)
-					InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				else
-					InfoMessage:inform("Minimum zoom step is "..minstep.."%. ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("Minimum zoom step is "..minstep.."%. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -2623,7 +2623,7 @@ function UniReader:addAllCommands()
 				unireader.jump_history.cur = prev_jump_no
 				unireader:goto(unireader.jump_history[prev_jump_no].page, true)
 			else
-				InfoMessage:inform("Already first jump ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("Already first jump ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			end
 		end)
 	self.commands:add(KEY_BACK,MOD_SHIFT,"Back",
@@ -2638,7 +2638,7 @@ function UniReader:addAllCommands()
 					unireader.jump_history.cur = unireader.jump_history.cur + 1
 				end
 			else
-				InfoMessage:inform("Already last jump ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("Already last jump ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			end
 		end)
 	self.commands:addGroup("vol-/+",{Keydef:new(KEY_VPLUS,nil),Keydef:new(KEY_VMINUS,nil)},
@@ -2751,7 +2751,7 @@ function UniReader:addAllCommands()
 		"toggle battery level logging",
 		function(unireader)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), nil, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
 			self:redrawCurrentPage()
 		end)
@@ -2770,9 +2770,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			ok = unireader:addBookmark(self.pageno)
 			if not ok then
-				InfoMessage:inform("Page already marked ", 1500, 1, MSG_WARN)
+				InfoMessage:inform("Page already marked ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			else
-				InfoMessage:inform("Page marked ", 1500, 1, MSG_WARN)
+				InfoMessage:inform("Page marked ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			end
 		end)
 	self.commands:addGroup(MOD_ALT.."K/L",{
@@ -2827,7 +2827,7 @@ function UniReader:addAllCommands()
 		"toggle showing page overlap areas",
 		function(unireader)
 			unireader.show_overlap_enable = not unireader.show_overlap_enable
-			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON" or "OFF"), nil, 1, MSG_AUX)
+			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_overlap_enable", unireader.show_overlap_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2836,7 +2836,7 @@ function UniReader:addAllCommands()
 		"toggle page-buttons mode: viewport/page",
 		function(unireader)
 			unireader.page_mode_enable = not unireader.page_mode_enable
-			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), nil, 1, MSG_AUX)
+			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("page_mode_enable", unireader.page_mode_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2845,7 +2845,7 @@ function UniReader:addAllCommands()
 		"toggle right-to-left mode on/off",
 		function(unireader)
 			unireader.rtl_mode_enable = not unireader.rtl_mode_enable
-			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON" or "OFF"), nil, 1, MSG_AUX)
+			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("rtl_mode_enable", unireader.rtl_mode_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2854,7 +2854,7 @@ function UniReader:addAllCommands()
 		"toggle comics mode on/off",
 		function(unireader)
 			unireader.comics_mode_enable = not unireader.comics_mode_enable
-			InfoMessage:inform("Comics mode "..(unireader.comics_mode_enable and "ON" or "OFF"), nil, 1, MSG_AUX)
+			InfoMessage:inform("Comics mode "..(unireader.comics_mode_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("comics_mode_enable", unireader.comics_mode_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2863,17 +2863,17 @@ function UniReader:addAllCommands()
 		"reset default reader preferences",
 		function(unireader)
 			G_reader_settings:delSetting("reader_preferences")
-			InfoMessage:inform("Reseting reader preferences", 1000, 1, MSG_AUX)
+			InfoMessage:inform("Reseting reader preferences", DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 		end)
 	
 	self.commands:add(KEY_C, MOD_ALT, "C",
 		"clear reader association with this doc",
 		function(unireader)
 			if self.settings:readSetting("reader_association") == "N/A" then
-				InfoMessage:inform("No reader associated", 1000, 1, MSG_AUX)
+				InfoMessage:inform("No reader associated", DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 			else
 				self.settings:saveSetting("reader_association", "N/A")
-				InfoMessage:inform("Clearing reader association", 1000, 1, MSG_AUX)
+				InfoMessage:inform("Clearing reader association", DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 			end
 		end)
 
@@ -2924,13 +2924,13 @@ function UniReader:addAllCommands()
 			unireader.bbox.enabled = true
 			Debug("bbox", unireader.pageno, unireader.bbox)
 			unireader.globalzoom_mode = unireader.ZOOM_FIT_TO_CONTENT -- use bbox
-			InfoMessage:inform("Manual crop setting saved. ", 2000, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop setting saved. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 		end)
 	self.commands:add(KEY_Z,MOD_SHIFT,"Z",
 		"reset crop",
 		function(unireader)
 			unireader.bbox[unireader.pageno] = nil;
-			InfoMessage:inform("Manual crop setting removed. ", 2000, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop setting removed. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			Debug("bbox remove", unireader.pageno, unireader.bbox);
 		end)
 	self.commands:add(KEY_Z,MOD_ALT,"Z",
@@ -2938,9 +2938,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			unireader.bbox.enabled = not unireader.bbox.enabled;
 			if unireader.bbox.enabled then
-				InfoMessage:inform("Manual crop enabled. ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("Manual crop enabled. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			else
-				InfoMessage:inform("Manual crop disabled. ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("Manual crop disabled. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			end
 			Debug("bbox override", unireader.bbox.enabled);
 		end)
@@ -2970,7 +2970,7 @@ function UniReader:addAllCommands()
 
 			fb.bb:invertRect( 0,y_s, G_width,1 )
 			fb.bb:invertRect( x_s,0, 1,G_height )
-			InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+			InfoMessage:inform(running_corner.." bbox ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
 				running_corner.." bounding box")
 			fb:refresh(1)
 
@@ -3006,7 +3006,7 @@ function UniReader:addAllCommands()
 							Debug("change top-left", bbox, "to", new_bbox)
 							running_corner = "bottom-right"
 							Screen:restoreFromSavedBB()
-							InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+							InfoMessage:inform(running_corner.." bbox ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
 								running_corner.." bounding box")
 							fb:refresh(1)
 							x_s = x+w
@@ -3122,7 +3122,7 @@ function UniReader:addAllCommands()
 			x,y,w,h = unireader:getRectInScreen( new_bbox["x0"], new_bbox["y0"], new_bbox["x1"], new_bbox["y1"] )
 			fb.bb:invertRect( x,y, w,h )
 			--fb.bb:invertRect( x+1,y+1, w-2,h-2 ) -- just border?
-			InfoMessage:inform("New page bbox ", 2000, 1, MSG_WARN, "New page bounding box")
+			InfoMessage:inform("New page bbox ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN, "New page bounding box")
 			self:redrawCurrentPage()
 
 			self.rcount = self.rcountmax -- force next full refresh
@@ -3329,17 +3329,17 @@ function UniReader:addAllCommands()
 				unireader.shift_x = unireader.shift_x * 2
 				if unireader.shift_x >= G_width then
 					unireader.shift_x = G_width
-					InfoMessage:inform("Maximum X-panning step is "..G_width..". ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("Maximum X-panning step is "..G_width..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				end
 				self.settings:saveSetting("shift_x", self.shift_x)
-				InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			else
 				if unireader.shift_x >= 2*minstep then
 					unireader.shift_x = math.ceil(unireader.shift_x / 2)
 					self.settings:saveSetting("shift_x", self.shift_x)
-					InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				else
-					InfoMessage:inform("Minimum X-panning step is "..minstep..". ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("Minimum X-panning step is "..minstep..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -3352,17 +3352,17 @@ function UniReader:addAllCommands()
 				unireader.shift_y = unireader.shift_y * 2
 				if unireader.shift_y >= G_height then
 					unireader.shift_y = G_height
-					InfoMessage:inform("Maximum Y-panning step is "..G_height..". ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("Maximum Y-panning step is "..G_height..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				end
 				self.settings:saveSetting("shift_y", self.shift_y)
-				InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			else
 				if unireader.shift_y >= 2*minstep then
 					unireader.shift_y = math.ceil(unireader.shift_y / 2)
 					self.settings:saveSetting("shift_y", self.shift_y)
-					InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				else
-					InfoMessage:inform("Minimum Y-panning step is "..minstep..". ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("Minimum Y-panning step is "..minstep..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -3402,7 +3402,7 @@ function UniReader:addAllCommands()
 		"show/hide link underlines",
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
-			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON" or "OFF"), nil, 1, MSG_AUX)
+			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_links_enable", unireader.show_links_enable)
 			self:redrawCurrentPage()
 		end
@@ -3412,7 +3412,7 @@ function UniReader:addAllCommands()
 		function(unireader)
 			local links = unireader:getPageLinks( unireader.pageno )
 			if links == nil or next(links) == nil then
-				InfoMessage:inform("No links on this page ", 2000, 1, MSG_WARN)
+				InfoMessage:inform("No links on this page ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			else
 				Debug("shortcuts",SelectMenu.item_shortcuts)
 
@@ -3445,7 +3445,7 @@ function UniReader:addAllCommands()
 				end
 
 				if page_links == 0 then
-					InfoMessage:inform("No page links on this page ", 2000, 1, MSG_WARN)
+					InfoMessage:inform("No page links on this page ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 					return
 				end
 


### PR DESCRIPTION
Cleans up defaults.lua (removes some values that should not be set by the user) and introduces DINFO_TIMEOUT_FAST and DINFO_TIMEOUT_SLOW. All :inform() calls in unireader.lua that had nil as the timeout have DINFO_TIMEOUT_FAST now, and all other values (1000, 1500, 2000) have DINFO_TIMEOUT_SLOW. When run in emulator, :inform() will always use value set as DINFO_TIMEOUT_SLOW.
