### PR TITLE
speeds up info messages of toggles etc. in emulator

### DIFF
--- a/dialog.lua
+++ b/dialog.lua
@@ -137,7 +137,7 @@ function InfoMessage:inform(text, msec, refresh_mode, message_importance, altern
 	if not popup then return end -- to avoid drawing popup window
 	self.ImageFile = self.Images[message_importance] -- select proper image for window
 	if util.isEmulated()==1 and msec == 0 then
-		msec = DINFO_TIMEOUT_SLOW
+		msec = 300
 	end
 	if not msec or msec == 0 then
 		InfoMessage:show(text, refresh_mode)


### PR DESCRIPTION
In an attempt to slow down Info Messages on emulator, so they can be read, we made them too slow. This will make them "just right" - comparable to how they appear on Kindle.
