### PR TITLE
Don't slow down :inform() when modifying bbox (and other very minor fixes)

### DIFF
--- a/dialog.lua
+++ b/dialog.lua
@@ -105,10 +105,10 @@ Adding new parameters -- 'message_importance' & 'alternative_voice_message' -- i
 Brief description of the function parameters
 -- text : is the text message for visual and (if 'alternative_voice_message' isn't defined) voice notification
 -- msec : parameter to define visual notification method
-	msec=0: one calls InfoMessage:show(), otherwise one calls showInfoMsgWithDelay()
-	msec>0: with either predefines msec-value or
-	msec<0: autocalculated from the text length: one may eventually add user-configurable 
-		parameter 'reading_speed' that would define the popup exposition for this regime
+    nil:	display the message immediately without slowing it down on the emulator
+    DINFO_TIMEOUT_FAST:	display the message immediately, but slow it down on the emulator
+	DINFO_TIMEOUT_SLOW: display the message with the 1500ms delay
+	msec<0: the delay is auto-calculated from the text length
 -- message_importance : parameter separating various messages on
 	MSG_AUX		- not obligatory messages that might be readily avoided
 	MSG_WARN	- warnings (important messages)

--- a/dialog.lua
+++ b/dialog.lua
@@ -106,8 +106,8 @@ Brief description of the function parameters
 -- text : is the text message for visual and (if 'alternative_voice_message' isn't defined) voice notification
 -- msec : parameter to define visual notification method
 	nil:	display the message immediately without slowing it down on the emulator
-	DINFO_TIMEOUT_FAST:	display the message immediately, but slow it down on the emulator
-	DINFO_TIMEOUT_SLOW: display the message with the 1500ms delay
+	DINFO_TIMEOUT_FAST:	display the message and return immediately on Kindle, but after a delay on the emulator
+	DINFO_TIMEOUT_SLOW: display the message and return after a delay
 	msec<0: the delay is auto-calculated from the text length
 -- message_importance : parameter separating various messages on
 	MSG_AUX		- not obligatory messages that might be readily avoided

--- a/dialog.lua
+++ b/dialog.lua
@@ -105,8 +105,8 @@ Adding new parameters -- 'message_importance' & 'alternative_voice_message' -- i
 Brief description of the function parameters
 -- text : is the text message for visual and (if 'alternative_voice_message' isn't defined) voice notification
 -- msec : parameter to define visual notification method
-    nil:	display the message immediately without slowing it down on the emulator
-    DINFO_TIMEOUT_FAST:	display the message immediately, but slow it down on the emulator
+	nil:	display the message immediately without slowing it down on the emulator
+	DINFO_TIMEOUT_FAST:	display the message immediately, but slow it down on the emulator
 	DINFO_TIMEOUT_SLOW: display the message with the 1500ms delay
 	msec<0: the delay is auto-calculated from the text length
 -- message_importance : parameter separating various messages on

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -420,12 +420,11 @@ function FileChooser:addAllCommands()
 		"delete selected item",
 		function(self)
 			local pos = self.perpage*(self.page-1)+self.current
-			local confirm = "Please, press key Y to confirm deleting"
 			if pos > #self.dirs then -- file
 				if InfoMessage.InfoMethod[MSG_CONFIRM] == 0 then	-- silent regime
 					self:deleteFileAtPosition(pos)
 				else
-					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM, confirm)
+					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM)
 					if ReturnKey() == KEY_Y then self:deleteFileAtPosition(pos) end
 				end
 			elseif self.dirs[pos] == ".." then 
@@ -434,7 +433,7 @@ function FileChooser:addAllCommands()
 				if InfoMessage.InfoMethod[MSG_CONFIRM] == 0 then -- silent regime
 					self:deleteFolderAtPosition(pos)
 				else
-					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM, confirm)
+					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM)
 					if ReturnKey() == KEY_Y then self:deleteFolderAtPosition(pos) end
 				end
 			end
@@ -530,15 +529,13 @@ function FileChooser:addAllCommands()
 	self.commands:add(KEY_C, MOD_SHIFT, "C",
 		"copy file to 'clipboard'",
 		function(self)
-			-- TODO (NuPogodi, 27.09.12): overwrite?
 			local file = self:FullFileName()
 			if file then
 				os.execute("cp "..InQuotes(file).." "..self.clipboard)
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
 				os.execute("cp "..InQuotes(DocToHistory(file)).." "
 					..InQuotes(DocToHistory(self.clipboard.."/"..fn)) )
-				InfoMessage:inform("File copied to clipboard ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
-					"The file has been copied to clipboard.")
+				InfoMessage:inform("File copied to clipboard ", DINFO_TIMEOUT_FAST, 1, MSG_WARN)
 			end
 		end
 	)
@@ -551,8 +548,7 @@ function FileChooser:addAllCommands()
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
 				os.rename(file, self.clipboard.."/"..fn)
 				os.rename(DocToHistory(file), DocToHistory(self.clipboard.."/"..fn))
-				InfoMessage:inform("File moved to clipboard ", DINFO_TIMEOUT_FAST, 0, MSG_WARN,
-					"The file has been moved to clipboard.")
+				InfoMessage:inform("File moved to clipboard ", DINFO_TIMEOUT_FAST, 0, MSG_WARN)
 				local pos = self.perpage*(self.page-1)+self.current
 				table.remove(self.files, pos-#self.dirs)
 				self.items = self.items - 1
@@ -684,8 +680,7 @@ function FileChooser:deleteFolderAtPosition(pos)
 		self.items = #self.dirs + #self.files
 		self.current, self.page = gotoTargetItem(pos, self.items, pos, self.page, self.perpage)
 	else
-		InfoMessage:inform("Folder can't be deleted! ", DINFO_TIMEOUT_SLOW, 1, MSG_ERROR,
-			"This folder can not be deleted! Please, make sure that it is empty.")
+		InfoMessage:inform("Directory not empty ", DINFO_TIMEOUT_SLOW, 1, MSG_ERROR)
 	end
 end
 
@@ -715,7 +710,6 @@ function gotoTargetItem(target_item, all_items, current_item, current_page, perp
 end
 
 function warningUnsupportedFunction()
-	InfoMessage:inform("Unsupported function! ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN,
-		"The requested function is not supported.")
+	InfoMessage:inform("Unsupported function ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 	return nil
 end

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -64,7 +64,6 @@ function FileInfo:formatDiskSizeInfo()
 end
 
 function FileInfo:getFolderContent()
-	InfoMessage:inform("Scanning folder...", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 	local tmp = io.popen('du -a \"'..self.pathfile..'\"', "r")
 	local dirs, files, books, size, name, output, ftype, j = -1, 0, 0, 0
 	for output in tmp:lines() do

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -459,7 +459,7 @@ function KOPTConfig:modBBox(koptreader)
 
 	fb.bb:invertRect( 0,y_s, G_width,1 )
 	fb.bb:invertRect( x_s,0, 1,G_height )
-	InfoMessage:inform(running_corner.." bbox ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
+	InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
 		running_corner.." bounding box")
 	fb:refresh(1)
 
@@ -495,7 +495,7 @@ function KOPTConfig:modBBox(koptreader)
 					Debug("change top-left", bbox, "to", new_bbox)
 					running_corner = "bottom-right"
 					Screen:restoreFromSavedBB()
-					InfoMessage:inform(running_corner.." bbox ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
+					InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
 						running_corner.." bounding box")
 					fb:refresh(1)
 					x_s = x+w

--- a/reader.lua
+++ b/reader.lua
@@ -35,7 +35,7 @@ function openFile(filename)
 
 	reader = ReaderChooser:getReaderByName(filename)
 	if reader then
-		InfoMessage:inform("Opening document... ", DINFO_TIMEOUT_FAST, 0, MSG_AUX)
+		InfoMessage:inform("Opening document... ", nil, 0, MSG_AUX)
 		reader:preLoadSettings(filename)
 		local ok, err = reader:open(filename)
 		if ok then

--- a/unireader.lua
+++ b/unireader.lua
@@ -2966,7 +2966,7 @@ function UniReader:addAllCommands()
 
 			fb.bb:invertRect( 0,y_s, G_width,1 )
 			fb.bb:invertRect( x_s,0, 1,G_height )
-			InfoMessage:inform(running_corner.." bbox ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
+			InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
 				running_corner.." bounding box")
 			fb:refresh(1)
 
@@ -3002,7 +3002,7 @@ function UniReader:addAllCommands()
 							Debug("change top-left", bbox, "to", new_bbox)
 							running_corner = "bottom-right"
 							Screen:restoreFromSavedBB()
-							InfoMessage:inform(running_corner.." bbox ", DINFO_TIMEOUT_FAST, 1, MSG_WARN,
+							InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
 								running_corner.." bounding box")
 							fb:refresh(1)
 							x_s = x+w


### PR DESCRIPTION
1. We shouldn't delay the calls to :inform() when modifying bbox (Shift-X) on the emulator. Otherwise, the popup window will disappear after a very short delay.
2. Document the 'msec' parameter of :inform() method in the comments above it in dialog.lua.
3. Get rid of some of the "polite" alternative voice messages in cases where the default one will do perfectly.
4. Get rid of the useless "Scanning folder..." message as this operation is fast enough to not deserve any such message.
5. Explain the reason why a directory cannot be deleted instead of just stating this as a fact. (and get rid of those exclamation marks, no need for shouting, the world is a noisy enough place as it is :)
6. Don't try to slow down the "Opening document..." message on the emulator because this would break the "open last file" method of KPV invocation.
