### PR TITLE
bugfixes for fit-to-content-width zoom mode for documents with pages of ...

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1332,9 +1332,7 @@ function UniReader:setzoom(page, preCache)
 			-- We must handle previous page turn as a special cases,
 			-- because we want to arrive at the bottom of previous page.
 			-- Since this a real page turn, we need to recalculate stuff.
---			if (x1 - x0) < pwidth then
-				self.globalzoom = width / (x1 - x0)
---			end
+			self.globalzoom = width / (x1 - x0)
 			if self.globalzoom * pheight > G_height then
 				self.offset_x = -1 * x0 * self.globalzoom
 				self.content_top = -1 * y0 * self.globalzoom

--- a/unireader.lua
+++ b/unireader.lua
@@ -1324,7 +1324,7 @@ function UniReader:setzoom(page, preCache)
 		self.offset_y = -1 * y0 * self.globalzoom
 		self.content_top = self.offset_y
 		-- enable pan mode in ZOOM_FIT_TO_CONTENT_WIDTH
-		if self.globalzoom * pheight > G_height then
+		if self.globalzoom * pheight > height then
 			self.globalzoom_mode = self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN
 		end	
 	elseif self.globalzoom_mode == self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN then
@@ -1333,7 +1333,7 @@ function UniReader:setzoom(page, preCache)
 			-- because we want to arrive at the bottom of previous page.
 			-- Since this a real page turn, we need to recalculate stuff.
 			self.globalzoom = width / (x1 - x0)
-			if self.globalzoom * pheight > G_height then
+			if self.globalzoom * pheight > height then
 				self.offset_x = -1 * x0 * self.globalzoom
 				self.content_top = -1 * y0 * self.globalzoom
 				self.offset_y = fb.bb:getHeight() - self.fullheight

--- a/unireader.lua
+++ b/unireader.lua
@@ -1324,18 +1324,24 @@ function UniReader:setzoom(page, preCache)
 		self.offset_y = -1 * y0 * self.globalzoom
 		self.content_top = self.offset_y
 		-- enable pan mode in ZOOM_FIT_TO_CONTENT_WIDTH
-		self.globalzoom_mode = self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN
+		if self.globalzoom * pheight > G_height then
+			self.globalzoom_mode = self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN
+		end	
 	elseif self.globalzoom_mode == self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN then
 		if self.content_top == -2012 then
 			-- We must handle previous page turn as a special cases,
 			-- because we want to arrive at the bottom of previous page.
 			-- Since this a real page turn, we need to recalculate stuff.
-			if (x1 - x0) < pwidth then
+--			if (x1 - x0) < pwidth then
 				self.globalzoom = width / (x1 - x0)
+--			end
+			if self.globalzoom * pheight > G_height then
+				self.offset_x = -1 * x0 * self.globalzoom
+				self.content_top = -1 * y0 * self.globalzoom
+				self.offset_y = fb.bb:getHeight() - self.fullheight
+			else
+				self.globalzoom_mode = self.ZOOM_FIT_TO_CONTENT_WIDTH
 			end
-			self.offset_x = -1 * x0 * self.globalzoom
-			self.content_top = -1 * y0 * self.globalzoom
-			self.offset_y = fb.bb:getHeight() - self.fullheight
 		end
 	elseif self.globalzoom_mode == self.ZOOM_FIT_TO_CONTENT_HEIGHT then
 		if (y1 - y0) < pheight then


### PR DESCRIPTION
...different size

Fixes 2 bugs in fit-to-content-width mode with documents that have pages of different size (e.g. manga with spreads)
1. if height of the page is less than hight of the screen, the page should be centered.
2. when pressing pg_bk, zoom mode should be recalculated.
