### PR TITLE
Add any link jump to the history.

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1579,14 +1579,16 @@ function UniReader:addBookmark(pageno)
 end
 
 -- change current page and cache next page after rendering
-function UniReader:goto(no, is_ignore_jump)
+function UniReader:goto(no, is_ignore_jump, pos_type)
 	local numpages = self.doc:getPages()
 	if no < 1 or no > numpages then
 		return
 	end
 
 	-- for jump_history
-	if not is_ignore_jump then
+	if pos_type == "link" then
+		self:addJump(self.pageno)
+	elseif not is_ignore_jump then
 		-- distinguish jump from normal page turn
 		if self.pageno and math.abs(self.pageno - no) > 1 then
 			self:addJump(self.pageno)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1586,11 +1586,9 @@ function UniReader:goto(no, is_ignore_jump, pos_type)
 	end
 
 	-- for jump_history
-	if pos_type == "link" then
-		self:addJump(self.pageno)
-	elseif not is_ignore_jump then
+	if not is_ignore_jump then
 		-- distinguish jump from normal page turn
-		if self.pageno and math.abs(self.pageno - no) > 1 then
+		if pos_type == "link" or (self.pageno and math.abs(self.pageno - no) > 1) then
 			self:addJump(self.pageno)
 		end
 	end


### PR DESCRIPTION
If you follow a local link in the PDF file which points to a place only one page away from the current page and then press Back it will bring you to some random location (depending on the previous jump history). But normally you would expect to be returned to the link's location, regardless of its distance from the target page. This PR fixes this problem, also raised as an issue #575.
