### PR TITLE
Optimize UniReader:redrawCurrentPage()

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -1633,7 +1633,7 @@ function UniReader:goto(no, is_ignore_jump)
 end
 
 function UniReader:redrawCurrentPage()
-	self:goto(self.pageno)
+	self:show(self.pageno)
 end
 
 function UniReader:nextView()
@@ -2744,10 +2744,11 @@ function UniReader:addAllCommands()
 				"Page:", "current page "..self.pageno.." of "..numpages, true)
 			-- convert string to number
 			if not pcall(function () page = math.floor(page) end)
-			or page < 1 or page > numpages then
-				page = unireader.pageno
+			or page < 1 or page > numpages or page == unireader.pageno then
+				unireader:redrawCurrentPage()
+			else
+				unireader:goto(page)
 			end
-			unireader:goto(page)
 		end)
 	self.commands:add(KEY_H,nil,"H",
 		"show help page",


### PR DESCRIPTION
1. There is no need to call the :goto() method from `UniReader:redrawCurrentPage()` which does the extra work of adding to jump history and (most importantly, as the jump history is ignored in this case anyway) pre-caching, which is not relevant for the simple task of redrawing the current page.
2. The page goto `G` function can now be optimized to avoid pre-caching if the page has not actually changed.
