### PR TITLE
Adds zip ext to PDFReader and makes extensions accesible through defaults.lua

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -73,6 +73,6 @@ DPDFREADER_EXT = ";pdf;xps;cbz;zip;"
 DDJVUREADER_EXT = ";djvu;"
 DPDFREFLOW_EXT = ";pdf;"
 DDJVUREFLOW_EXT = ";djvu;"
-DCREREADER_EXT = ";epub;txt;rtf;htm;html;mobi;prc;azw;fb2;chm;pdb;doc;tcr;zip;"
+DCREREADER_EXT = ";epub;txt;rtf;htm;html;mobi;prc;azw;fb2;chm;pdb;doc;tcr;zip;" 	-- seems to accept pdb-files for PalmDoc only
 DPICVIEWER_EXT = ";jpg;jpeg;"
 

--- a/defaults.lua
+++ b/defaults.lua
@@ -68,3 +68,11 @@ DPICVIEWER_COMICS_MODE_ENABLE = true
 DPICVIEWER_RTL_MODE_ENABLE = false
 DPICVIEWER_PAGE_MODE_ENABLE = false
 
+-- supported extensions
+DPDFREADER_EXT = ";pdf;xps;cbz;zip;"
+DDJVUREADER_EXT = ";djvu;"
+DPDFREFLOW_EXT = ";pdf;"
+DDJVUREFLOW_EXT = ";djvu;"
+DCREREADER_EXT = ";epub;txt;rtf;htm;html;mobi;prc;azw;fb2;chm;pdb;doc;tcr;zip;"
+DPICVIEWER_EXT = ";jpg;jpeg;"
+

--- a/readerchooser.lua
+++ b/readerchooser.lua
@@ -7,6 +7,7 @@ require "djvureader"
 require "koptreader"
 require "picviewer"
 require "crereader"
+require "defaults"
 
 registry = {
 	-- registry format:

--- a/readerchooser.lua
+++ b/readerchooser.lua
@@ -18,7 +18,6 @@ registry = {
 	DJVUReflow = {KOPTReader, DDJVUREFLOW_EXT, 2},
 	CREReader  = {CREReader, DCREREADER_EXT, 2},
 	PICViewer = {PICViewer, DPICVIEWER_EXT, 1},
-	-- seems to accept pdb-files for PalmDoc only
 }
 
 ReaderChooser = {

--- a/readerchooser.lua
+++ b/readerchooser.lua
@@ -11,12 +11,12 @@ require "crereader"
 registry = {
 	-- registry format:
 	-- reader_name = {reader_object, supported_formats, priority}
-	PDFReader  = {PDFReader, ";pdf;xps;cbz;", 1},
-	DJVUReader = {DJVUReader, ";djvu;", 1},
-	PDFReflow = {KOPTReader, ";pdf;", 2},
-	DJVUReflow = {KOPTReader, ";djvu;", 2},
-	CREReader  = {CREReader, ";epub;txt;rtf;htm;html;mobi;prc;azw;fb2;chm;pdb;doc;tcr;zip;", 1},
-	PICViewer = {PICViewer, ";jpg;jpeg;", 1},
+	PDFReader  = {PDFReader, DPDFREADER_EXT, 1},
+	DJVUReader = {DJVUReader, DDJVUREADER_EXT, 1},
+	PDFReflow = {KOPTReader, DPDFREFLOW_EXT, 2},
+	DJVUReflow = {KOPTReader, DDJVUREFLOW_EXT, 2},
+	CREReader  = {CREReader, DCREREADER_EXT, 2},
+	PICViewer = {PICViewer, DPICVIEWER_EXT, 1},
 	-- seems to accept pdb-files for PalmDoc only
 }
 


### PR DESCRIPTION
A lot of manga comes as .zip, and not .cbz (for all intents and purposes, it
is the same thing, just the extension is different). This allows the user to
choose the reader to open her zip files - PDFReader or CREReader, in the same
way she can choose to use PDFReader or PDFReflow for pdf files. I also moved
the list of supported extensions to defaults.lua.
