### PR TITLE
Changes keybindings for zoom modes so zoom to content is used without Shift

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -2696,42 +2696,42 @@ function UniReader:addAllCommands()
 		end)
 	-- to leave or to erase 8 hotkeys switching zoom-mode directly?
 
-	self.commands:add(KEY_A,nil,"A",
+	self.commands:add(KEY_A,MOD_SHIFT,"A",
 		"zoom to fit page",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_PAGE)
 		end)
-	self.commands:add(KEY_A,MOD_SHIFT,"A",
+	self.commands:add(KEY_A,nil,"A",
 		"zoom to fit content",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_CONTENT)
 		end)
-	self.commands:add(KEY_S,nil,"S",
+	self.commands:add(KEY_S,MOD_SHIFT,"S",
 		"zoom to fit page width",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_PAGE_WIDTH)
 		end)
-	self.commands:add(KEY_S,MOD_SHIFT,"S",
+	self.commands:add(KEY_S,nil,"S",
 		"zoom to fit content width",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_CONTENT_WIDTH)
 		end)
-	self.commands:add(KEY_D,nil,"D",
+	self.commands:add(KEY_D,MOD_SHIFT,"D",
 		"zoom to fit page height",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_PAGE_HEIGHT)
 		end)
-	self.commands:add(KEY_D,MOD_SHIFT,"D",
+	self.commands:add(KEY_D,nil,"D",
 		"zoom to fit content height",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_CONTENT_HEIGHT)
 		end)
-	self.commands:add(KEY_F,nil,"F",
+	self.commands:add(KEY_F,MOD_SHIFT,"F",
 		"zoom to fit margin 2-column mode",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_CONTENT_HALF_WIDTH_MARGIN)
 		end)
-	self.commands:add(KEY_F,MOD_SHIFT,"F",
+	self.commands:add(KEY_F,nil,"F",
 		"zoom to fit content 2-column mode",
 		function(unireader)
 			unireader:setglobalzoom_mode(unireader.ZOOM_FIT_TO_CONTENT_HALF_WIDTH)


### PR DESCRIPTION
This will probably not be accepted, but I thought I should try it anyway. I think that, due to the small size of Kindle screen, a user is MUCH more likely to use zoom to content modes compared to zoom to page modes. Therefore, I think zoom to content modes should be the ones she gets without pressing Shift. I know that some might be used to it, but I think it won't take them long to adjust to better. :) What do you guys think?
