### PR TITLE
Bugfix: toggle popup windows don't disappear

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -40,7 +40,7 @@ DBATTERY_LOGGING = false
 DBACKGROUND_COLOR = 8
 
 -- timeout for info messages in ms
-DINFO_TIMEOUT_FAST=0
+DINFO_TIMEOUT_FAST=1
 DINFO_TIMEOUT_SLOW=1500
 
 -- toggle defaults
@@ -75,4 +75,3 @@ DPDFREFLOW_EXT = ";pdf;"
 DDJVUREFLOW_EXT = ";djvu;"
 DCREREADER_EXT = ";epub;txt;rtf;htm;html;mobi;prc;azw;fb2;chm;pdb;doc;tcr;zip;" 	-- seems to accept pdb-files for PalmDoc only
 DPICVIEWER_EXT = ";jpg;jpeg;"
-

--- a/dialog.lua
+++ b/dialog.lua
@@ -136,7 +136,7 @@ function InfoMessage:inform(text, msec, refresh_mode, message_importance, altern
 	end
 	if not popup then return end -- to avoid drawing popup window
 	self.ImageFile = self.Images[message_importance] -- select proper image for window
-	if util.isEmulated()==1 and msec == 0 then
+	if util.isEmulated()==1 and msec == DINFO_TIMEOUT_FAST then
 		msec = 300
 	end
 	if not msec or msec == 0 then

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -577,9 +577,8 @@ function FileChooser:addAllCommands()
 		"toggle battery level logging",
 		function(self)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
-			self.pagedirty = true
 		end
 	)
 	self.commands:add(KEY_B, MOD_SHIFT, "B",

--- a/unireader.lua
+++ b/unireader.lua
@@ -2760,9 +2760,8 @@ function UniReader:addAllCommands()
 		"toggle battery level logging",
 		function(unireader)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
-			self:redrawCurrentPage()
 		end)
 	self.commands:add(KEY_T,nil,"T",
 		"show table of content (TOC)",
@@ -2836,7 +2835,7 @@ function UniReader:addAllCommands()
 		"toggle showing page overlap areas",
 		function(unireader)
 			unireader.show_overlap_enable = not unireader.show_overlap_enable
-			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON " or "OFF "), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_overlap_enable", unireader.show_overlap_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2845,27 +2844,24 @@ function UniReader:addAllCommands()
 		"toggle page-buttons mode: viewport/page",
 		function(unireader)
 			unireader.page_mode_enable = not unireader.page_mode_enable
-			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("page_mode_enable", unireader.page_mode_enable)
-			self:redrawCurrentPage()
 		end)
 
 	self.commands:add(KEY_U, nil, "U",
 		"toggle right-to-left mode on/off",
 		function(unireader)
 			unireader.rtl_mode_enable = not unireader.rtl_mode_enable
-			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON " or "OFF "), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("rtl_mode_enable", unireader.rtl_mode_enable)
-			self:redrawCurrentPage()
 		end)
 
 	self.commands:add(KEY_C, nil, "C",
 		"align the viewport to top/bottom",
 		function(unireader)
 			unireader.comics_mode_enable = not unireader.comics_mode_enable
-			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM " or "TOP "), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM" or "TOP"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("comics_mode_enable", unireader.comics_mode_enable)
-			self:redrawCurrentPage()
 		end)
 
 	self.commands:add(KEY_C, MOD_SHIFT, "C",
@@ -2946,9 +2942,8 @@ function UniReader:addAllCommands()
 		"toggle crop mode",
 		function(unireader)
 			unireader.bbox.enabled = not unireader.bbox.enabled;
-			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_FAST, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
 			Debug("bbox override", unireader.bbox.enabled);
-			self:redrawCurrentPage()
 		end)
 	self.commands:add(KEY_X,nil,"X",
 		"invert page bbox",
@@ -3408,7 +3403,7 @@ function UniReader:addAllCommands()
 		"show/hide link underlines",
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
-			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_links_enable", unireader.show_links_enable)
 			self:redrawCurrentPage()
 		end

--- a/unireader.lua
+++ b/unireader.lua
@@ -2760,8 +2760,9 @@ function UniReader:addAllCommands()
 		"toggle battery level logging",
 		function(unireader)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
+			self:redrawCurrentPage()
 		end)
 	self.commands:add(KEY_T,nil,"T",
 		"show table of content (TOC)",
@@ -2835,7 +2836,7 @@ function UniReader:addAllCommands()
 		"toggle showing page overlap areas",
 		function(unireader)
 			unireader.show_overlap_enable = not unireader.show_overlap_enable
-			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON " or "OFF "), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 			self.settings:saveSetting("show_overlap_enable", unireader.show_overlap_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2844,24 +2845,27 @@ function UniReader:addAllCommands()
 		"toggle page-buttons mode: viewport/page",
 		function(unireader)
 			unireader.page_mode_enable = not unireader.page_mode_enable
-			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 			self.settings:saveSetting("page_mode_enable", unireader.page_mode_enable)
+			self:redrawCurrentPage()
 		end)
 
 	self.commands:add(KEY_U, nil, "U",
 		"toggle right-to-left mode on/off",
 		function(unireader)
 			unireader.rtl_mode_enable = not unireader.rtl_mode_enable
-			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON " or "OFF "), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 			self.settings:saveSetting("rtl_mode_enable", unireader.rtl_mode_enable)
+			self:redrawCurrentPage()
 		end)
 
 	self.commands:add(KEY_C, nil, "C",
 		"align the viewport to top/bottom",
 		function(unireader)
 			unireader.comics_mode_enable = not unireader.comics_mode_enable
-			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM" or "TOP"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM " or "TOP "), DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
 			self.settings:saveSetting("comics_mode_enable", unireader.comics_mode_enable)
+			self:redrawCurrentPage()
 		end)
 
 	self.commands:add(KEY_C, MOD_SHIFT, "C",
@@ -2942,8 +2946,9 @@ function UniReader:addAllCommands()
 		"toggle crop mode",
 		function(unireader)
 			unireader.bbox.enabled = not unireader.bbox.enabled;
-			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_FAST, 1, MSG_WARN)
 			Debug("bbox override", unireader.bbox.enabled);
+			self:redrawCurrentPage()
 		end)
 	self.commands:add(KEY_X,nil,"X",
 		"invert page bbox",
@@ -3403,7 +3408,7 @@ function UniReader:addAllCommands()
 		"show/hide link underlines",
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
-			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_links_enable", unireader.show_links_enable)
 			self:redrawCurrentPage()
 		end

--- a/unireader.lua
+++ b/unireader.lua
@@ -2760,7 +2760,7 @@ function UniReader:addAllCommands()
 		"toggle battery level logging",
 		function(unireader)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
 		end)
 	self.commands:add(KEY_T,nil,"T",
@@ -2835,7 +2835,7 @@ function UniReader:addAllCommands()
 		"toggle showing page overlap areas",
 		function(unireader)
 			unireader.show_overlap_enable = not unireader.show_overlap_enable
-			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_overlap_enable", unireader.show_overlap_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2844,7 +2844,7 @@ function UniReader:addAllCommands()
 		"toggle page-buttons mode: viewport/page",
 		function(unireader)
 			unireader.page_mode_enable = not unireader.page_mode_enable
-			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page" or "viewport"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page " or "viewport "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("page_mode_enable", unireader.page_mode_enable)
 		end)
 
@@ -2852,7 +2852,7 @@ function UniReader:addAllCommands()
 		"toggle right-to-left mode on/off",
 		function(unireader)
 			unireader.rtl_mode_enable = not unireader.rtl_mode_enable
-			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("rtl_mode_enable", unireader.rtl_mode_enable)
 		end)
 
@@ -2860,7 +2860,7 @@ function UniReader:addAllCommands()
 		"align the viewport to top/bottom",
 		function(unireader)
 			unireader.comics_mode_enable = not unireader.comics_mode_enable
-			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM" or "TOP"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM " or "TOP "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("comics_mode_enable", unireader.comics_mode_enable)
 		end)
 
@@ -2942,7 +2942,7 @@ function UniReader:addAllCommands()
 		"toggle crop mode",
 		function(unireader)
 			unireader.bbox.enabled = not unireader.bbox.enabled;
-			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_FAST, 1, MSG_WARN)
 			Debug("bbox override", unireader.bbox.enabled);
 		end)
 	self.commands:add(KEY_X,nil,"X",
@@ -3403,7 +3403,7 @@ function UniReader:addAllCommands()
 		"show/hide link underlines",
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
-			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON" or "OFF"), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 			self.settings:saveSetting("show_links_enable", unireader.show_links_enable)
 			self:redrawCurrentPage()
 		end


### PR DESCRIPTION
Thanks to @kai771 's idea of setting the value of `DINFO_TIMEOUT_FAST=1` (in defaults.lua) we can still have the same behaviour of calls to InfoMessage:inform(..DINFO_TIMEOUT_FAST..) on both the emulator and the Kindle without the need to manually refresh the page after the call. 

Also, now we don't need to set pagedirty=true in filechooser when displaying a popup window with DINFO_TIMEOUT_FAST flag.

Also, add space to the end of the text messages passed to :inform() for symmetry.
