### PR TITLE
Cleanup InfoMessage:inform() API and its usage

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -170,7 +170,7 @@ function Commands:new(obj)
 			if G_charging_mode == false and G_screen_saver_mode == false then
 				if G_battery_logging then logBatteryLevel("SLEEP") end
 				Screen:saveCurrentBB()
-				InfoMessage:inform("Going into screensaver... ", DINFO_TIMEOUT_FAST, 0, MSG_AUX)
+				InfoMessage:inform("Going into screensaver... ", DINFO_NODELAY, 0, MSG_AUX)
 				Screen.kpv_rotation_mode = Screen.cur_rotation_mode
 				fb:setOrientation(Screen.native_rotation_mode)
 				util.sleep(1)
@@ -203,7 +203,7 @@ function Commands:new(obj)
 				Screen:saveCurrentBB()
 				Screen.kpv_rotation_mode = Screen.cur_rotation_mode
 				fb:setOrientation(Screen.native_rotation_mode)
-				InfoMessage:inform("Going into USB mode... ", DINFO_TIMEOUT_FAST, 0, MSG_AUX)
+				InfoMessage:inform("Going into USB mode... ", DINFO_NODELAY, 0, MSG_AUX)
 				util.sleep(1)
 				os.execute("killall -cont cvm")
 			end

--- a/crereader.lua
+++ b/crereader.lua
@@ -247,7 +247,7 @@ function CREReader:showJumpHist()
 	end
 
 	if #menu_items == 0 then
-		InfoMessage:inform("No jump history found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform("No jump history found ", DINFO_DELAY, 1, MSG_WARN)
 	else
 		-- if cur points to head, draw entry for current page
 		if self.jump_history.cur > #self.jump_history then
@@ -310,7 +310,7 @@ function CREReader:showBookMarks()
 			.." "..v.notes.." @ "..v.datetime)
 	end
 	if #menu_items == 0 then
-		InfoMessage:inform("No bookmark found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform("No bookmark found ", DINFO_DELAY, 1, MSG_WARN)
 	else
 		local bkmk_menu = SelectMenu:new{
 			menu_title = "Bookmarks",
@@ -352,7 +352,7 @@ function CREReader:gotoPrevNextTocEntry(direction)
 		self:fillToc()
 	end
 	if #self.toc == 0 then
-		InfoMessage:inform("No Table of Contents ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform("No Table of Contents ", DINFO_DELAY, 1, MSG_WARN)
 		return
 	end
 	-- search for current TOC-entry
@@ -523,7 +523,7 @@ function CREReader:adjustCreReaderCommands()
 				change = "Decreasing"
 			end
 			self.font_zoom = self.font_zoom + delta
-			InfoMessage:inform(change.." font size to "..self.font_zoom..". ", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform(change.." font size to "..self.font_zoom..". ", DINFO_NODELAY, 1, MSG_AUX)
 			Debug("font zoomed to", self.font_zoom)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:zoomFont(delta)
@@ -542,7 +542,7 @@ function CREReader:adjustCreReaderCommands()
 				self.line_space_percent = self.line_space_percent + 10
 				self.line_space_percent = math.min(self.line_space_percent, 200)
 			end
-			InfoMessage:inform("Changing line space to "..self.line_space_percent.."% ", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Changing line space to "..self.line_space_percent.."% ", DINFO_NODELAY, 1, MSG_AUX)
 			Debug("line spacing set to", self.line_space_percent)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:setDefaultInterlineSpace(self.line_space_percent)
@@ -596,7 +596,7 @@ function CREReader:adjustCreReaderCommands()
 			local prev_xpointer = self.doc:getXPointer()
 			if item_no then
 				Debug(face_list[item_no])
-				InfoMessage:inform("Redrawing with "..face_list[item_no].." ", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+				InfoMessage:inform("Redrawing with "..face_list[item_no].." ", DINFO_NODELAY, 1, MSG_AUX)
 				self.doc:setFontFace(face_list[item_no])
 				self.font_face = face_list[item_no]
 			end
@@ -608,15 +608,13 @@ function CREReader:adjustCreReaderCommands()
 		function(self)
 			self.default_font = self.font_face
 			G_reader_settings:saveSetting("cre_font", self.font_face)
-			InfoMessage:inform("Default document font set ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN,
-				"Default document font is saved")
+			InfoMessage:inform("Default document font set ", DINFO_DELAY, 1, MSG_WARN)
 		end
 	)
 	self.commands:add(KEY_F, MOD_ALT, "F",
 		"toggle font-weight: bold <> normal",
 		function(self)
-			
-			InfoMessage:inform("Changing font-weight...", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Changing font-weight...", DINFO_NODELAY, 1, MSG_AUX)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:toggleFontBolder()
 			self:goto(prev_xpointer, nil, "xpointer")
@@ -627,9 +625,9 @@ function CREReader:adjustCreReaderCommands()
 		function(self)
 			ok = self:addBookmark(self.doc:getXPointer())
 			if not ok then
-				InfoMessage:inform("Page already marked ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Page already marked ", DINFO_DELAY, 1, MSG_WARN)
 			else
-				InfoMessage:inform("Page marked ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Page marked ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end
 	)
@@ -661,7 +659,7 @@ function CREReader:adjustCreReaderCommands()
 				self.jump_history.cur = prev_jump_no
 				self:goto(self.jump_history[prev_jump_no].page, true, "xpointer")
 			else
-				InfoMessage:inform("Already first jump ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Already first jump ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end
 	)
@@ -673,7 +671,7 @@ function CREReader:adjustCreReaderCommands()
 				self.jump_history.cur = next_jump_no
 				self:goto(self.jump_history[next_jump_no].page, true, "xpointer")
 			else
-				InfoMessage:inform("Already last jump ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Already last jump ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end
 	)
@@ -687,7 +685,7 @@ function CREReader:adjustCreReaderCommands()
 			end
 			cre.setGammaIndex(self.gamma_index+delta)
 			self.gamma_index = cre.getGammaIndex()
-			InfoMessage:inform("Changing gamma to "..self.gamma_index..". ", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Changing gamma to "..self.gamma_index..". ", DINFO_NODELAY, 1, MSG_AUX)
 			self:redrawCurrentPage()
 		end
 	)
@@ -732,9 +730,9 @@ function CREReader:searchHighLight(search)
 	if found then
 		self.pos = pos -- first metch position
 		self:redrawCurrentPage()
-		InfoMessage:inform( found.." hits '"..search.."' pos "..pos, DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform( found.." hits '"..search.."' pos "..pos, DINFO_DELAY, 1, MSG_WARN)
 	else
-		InfoMessage:inform( "'"..search.."' not found in document ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform( "'"..search.."' not found in document ", DINFO_DELAY, 1, MSG_WARN)
 	end
 
 	self.last_search.search = search

--- a/defaults.lua
+++ b/defaults.lua
@@ -39,9 +39,9 @@ DBATTERY_LOGGING = false
 -- background colour: 8 = gray, 0 = white, 15 = black
 DBACKGROUND_COLOR = 8
 
--- timeout for info messages in ms
-DINFO_TIMEOUT_FAST=1
-DINFO_TIMEOUT_SLOW=1500
+-- delay for info messages in ms
+DINFO_NODELAY=0
+DINFO_DELAY=1500
 
 -- toggle defaults
 DUNIREADER_SHOW_OVERLAP_ENABLE = true

--- a/dialog.lua
+++ b/dialog.lua
@@ -91,59 +91,36 @@ function showInfoMsgWithDelay(text, msec, refresh_mode)
 	fb:refresh(refresh_mode)
 end
 
---[[ Unified function to inform user about smth. It is generally intended to replace showInfoMsgWithDelay() & InfoMessage:show().
-Since the former function is used in Lua-code more often than the latter, I kept here the same sequence of parameters as used in
-showInfoMsgWithDelay() + added two not obligatory parameters (see description below).
-
-Thus, this trick allows multiple text replaces thoughout the whole Lua-code: 'showInfoMsgWithDelay(' to 'InfoMessage:inform('
-Yet, it would be much better to accompany such replaces by adding the 'message_importance' and, if needed, by
-'alternative_voice_message' that is not so restricted in length as 'text'
-
-But replacing InfoMessage:show(...) by InfoMessage:inform(...) MUST be accompanied by adding the 2nd parameter -- either msec=nil or msec=0.
-Adding new parameters -- 'message_importance' & 'alternative_voice_message' -- is also appreciated.
-
+--[[
 Brief description of the function parameters
 -- text : is the text message for visual and (if 'alternative_voice_message' isn't defined) voice notification
--- msec : parameter to define visual notification method
-	nil:	display the message immediately without slowing it down on the emulator
-	DINFO_TIMEOUT_FAST:	display the message and return immediately on Kindle, but after a delay on the emulator
-	DINFO_TIMEOUT_SLOW: display the message and return after a delay
-	msec<0: the delay is auto-calculated from the text length
--- message_importance : parameter separating various messages on
+-- delay : parameter to define visual notification method
+	DINFO_NODELAY:	display the message and return immediately (screen content not restored)
+	DINFO_DELAY:	display the message and return after a delay (screen content restored)
+-- msgtype : parameter separating various messages on
 	MSG_AUX		- not obligatory messages that might be readily avoided
 	MSG_WARN	- warnings (important messages)
 	MSG_ERROR	- errors
 	MSG_CONFIRM	- confirmations
 	MSG_BUG		- bugs
--- alternative_voice_message: not obligatory parameter that allows to send longer messages to TTS-engine
+-- tts_text: not obligatory parameter that allows to send longer messages to TTS-engine
 	if not defined, the default 'text' will be TTS-voiced
 ]]
 
-function InfoMessage:inform(text, msec, refresh_mode, message_importance, alternative_voice_message)
-	-- temporary test for 'message_importance'; it might be further removed as soon
-	-- as every message will be properly marked by 'importance'
-	if not message_importance then message_importance = 5 end
-	local popup, voice = InfoMessage:getMethodForEvent(message_importance)
+function InfoMessage:inform(text, delay, refresh_mode, msgtype, tts_text)
+	local popup, voice = InfoMessage:getMethodForEvent(msgtype)
 	if voice then
-		alternative_voice_message = alternative_voice_message or text
-		say(alternative_voice_message)
-		-- here one may set pause -- it might be useful only if one sound message
-		-- is directly followed by another, otherwise it's just wasting of time.
-		--[[ if msec and msec ~=0 then
-			-- pause = 0.5sec + 40ms/character * string.len() / normalized_voice_speed
-			util.usleep(500000 + 40*alternative_voice_message:len*10000/self.TTSspeed)
-		end ]]
+		say(tts_text or text)
 	end
-	if not popup then return end -- to avoid drawing popup window
-	self.ImageFile = self.Images[message_importance] -- select proper image for window
-	if util.isEmulated()==1 and msec == DINFO_TIMEOUT_FAST then
-		msec = 300
-	end
-	if not msec or msec == 0 then
+	if not popup then return end
+	self.ImageFile = self.Images[msgtype]
+	if delay == DINFO_NODELAY then
 		InfoMessage:show(text, refresh_mode)
+		if util.isEmulated() == 1 then util.usleep(500000) end
+	elseif delay == DINFO_DELAY then
+		showInfoMsgWithDelay(text, delay, refresh_mode)
 	else
-		if msec < 0 then msec = 500 + string.len(text) * 50 end
-		showInfoMsgWithDelay(text, msec, refresh_mode)
+		Debug("InfoMessage:inform(), unrecognized delay=", delay)
 	end
 end
 
@@ -180,10 +157,10 @@ function InfoMessage:chooseEventForMethod(event)
 	event = event or 0
 	local item_no = 0
 	local event_list = {
-		"Messages (e.g. 'Scanning folder...')",
+		"Messages (e.g. 'Battery logging ON')",
 		"Warnings (e.g. 'Already first jump!')",
 		"Errors (e.g. 'Zip contains improper content!')",
-		"Confirmations (e.g. 'Press Y to confirm deleting')",
+		"Confirmations (e.g. 'Press Y to confirm')",
 		"Bugs",
 		}
 	while item_no ~= event and item_no < #event_list do

--- a/dialog.lua
+++ b/dialog.lua
@@ -157,7 +157,7 @@ function InfoMessage:chooseEventForMethod(event)
 	event = event or 0
 	local item_no = 0
 	local event_list = {
-		"Messages (e.g. 'Battery logging ON')",
+		"Messages (e.g. 'Battery logging on')",
 		"Warnings (e.g. 'Already first jump!')",
 		"Errors (e.g. 'Zip contains improper content!')",
 		"Confirmations (e.g. 'Press Y to confirm')",

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -424,7 +424,7 @@ function FileChooser:addAllCommands()
 				if InfoMessage.InfoMethod[MSG_CONFIRM] == 0 then	-- silent regime
 					self:deleteFileAtPosition(pos)
 				else
-					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM)
+					InfoMessage:inform("Press 'Y' to confirm ", DINFO_NODELAY, 0, MSG_CONFIRM)
 					if ReturnKey() == KEY_Y then self:deleteFileAtPosition(pos) end
 				end
 			elseif self.dirs[pos] == ".." then 
@@ -433,7 +433,7 @@ function FileChooser:addAllCommands()
 				if InfoMessage.InfoMethod[MSG_CONFIRM] == 0 then -- silent regime
 					self:deleteFolderAtPosition(pos)
 				else
-					InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM)
+					InfoMessage:inform("Press 'Y' to confirm ", DINFO_NODELAY, 0, MSG_CONFIRM)
 					if ReturnKey() == KEY_Y then self:deleteFolderAtPosition(pos) end
 				end
 			end
@@ -515,11 +515,11 @@ function FileChooser:addAllCommands()
 		end
 	)
 	self.commands:add(KEY_S, nil, "S",
-		"search among files",
+		"search files (single space matches all)",
 		function(self)
 			local keywords = InputBox:input(0, 0, "Search:")
 			if keywords then
-				InfoMessage:inform("Searching... ", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+				InfoMessage:inform("Searching... ", DINFO_NODELAY, 1, MSG_AUX)
 				FileSearcher:init( self.path )
 				FileSearcher:choose(keywords)
 			end
@@ -535,7 +535,7 @@ function FileChooser:addAllCommands()
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
 				os.execute("cp "..InQuotes(DocToHistory(file)).." "
 					..InQuotes(DocToHistory(self.clipboard.."/"..fn)) )
-				InfoMessage:inform("File copied to clipboard ", DINFO_TIMEOUT_FAST, 1, MSG_WARN)
+				InfoMessage:inform("File copied to clipboard ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end
 	)
@@ -548,7 +548,7 @@ function FileChooser:addAllCommands()
 				local fn = self.files[self.perpage*(self.page-1)+self.current - #self.dirs]
 				os.rename(file, self.clipboard.."/"..fn)
 				os.rename(DocToHistory(file), DocToHistory(self.clipboard.."/"..fn))
-				InfoMessage:inform("File moved to clipboard ", DINFO_TIMEOUT_FAST, 0, MSG_WARN)
+				InfoMessage:inform("File moved to clipboard ", DINFO_DELAY, 0, MSG_WARN)
 				local pos = self.perpage*(self.page-1)+self.current
 				table.remove(self.files, pos-#self.dirs)
 				self.items = self.items - 1
@@ -562,7 +562,7 @@ function FileChooser:addAllCommands()
 		function(self)
 			-- TODO (NuPogodi, 27.09.12): first test whether the clipboard is empty & answer respectively
 			-- TODO (NuPogodi, 27.09.12): overwrite?
-			InfoMessage:inform("Moving files from clipboard...", DINFO_TIMEOUT_FAST, 0, MSG_AUX)
+			InfoMessage:inform("Moving files from clipboard...", DINFO_NODELAY, 0, MSG_AUX)
 			for f in lfs.dir(self.clipboard) do
 				if lfs.attributes(self.clipboard.."/"..f, "mode") == "file" then
 					os.rename(self.clipboard.."/"..f, self.path.."/"..f)
@@ -577,7 +577,7 @@ function FileChooser:addAllCommands()
 		"toggle battery level logging",
 		function(self)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "on " or "off "), DINFO_DELAY, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
 		end
 	)
@@ -679,7 +679,7 @@ function FileChooser:deleteFolderAtPosition(pos)
 		self.items = #self.dirs + #self.files
 		self.current, self.page = gotoTargetItem(pos, self.items, pos, self.page, self.perpage)
 	else
-		InfoMessage:inform("Directory not empty ", DINFO_TIMEOUT_SLOW, 1, MSG_ERROR)
+		InfoMessage:inform("Directory not empty ", DINFO_DELAY, 1, MSG_ERROR)
 	end
 end
 
@@ -709,6 +709,6 @@ function gotoTargetItem(target_item, all_items, current_item, current_page, perp
 end
 
 function warningUnsupportedFunction()
-	InfoMessage:inform("Unsupported function ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+	InfoMessage:inform("Unsupported function ", DINFO_DELAY, 1, MSG_WARN)
 	return nil
 end

--- a/filehistory.lua
+++ b/filehistory.lua
@@ -205,8 +205,7 @@ function FileHistory:addAllCommands()
 				self.keywords = old_keywords
 			end
 			if #self.result < 1 then
-				InfoMessage:inform("No search hits ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN,
-					"The search has given no results")
+				InfoMessage:inform("No search hits ", DINFO_DELAY, 1, MSG_WARN)
 				-- restoring the original data
 				self.result = old_data
 				self.items = #self.result
@@ -238,7 +237,7 @@ function FileHistory:addAllCommands()
 				self.page = math.floor(item_no / self.perpage) + 1
 				self.pagedirty = true
 			else
-				InfoMessage:inform("File does not exist ", DINFO_TIMEOUT_SLOW, 1, MSG_ERROR)
+				InfoMessage:inform("File does not exist ", DINFO_DELAY, 1, MSG_ERROR)
 			end
 		end
 	)
@@ -252,8 +251,7 @@ function FileHistory:addAllCommands()
 				self:init()
 				self:setSearchResult(self.keywords)
 			else
-				InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM,
-					"Please, press key Y to delete the book history")
+				InfoMessage:inform("Press 'Y' to confirm ", DINFO_NODELAY, 0, MSG_CONFIRM)
 				if ReturnKey() == KEY_Y then
 					os.remove(DocToHistory(file_to_del))
 					self:init()
@@ -287,7 +285,7 @@ function FileHistory:choose(keywords)
 
 	-- NuPogodi, 30.09.12: immediate quit (no redraw), if empty
 	if self:setSearchResult(keywords) < 1 then
-		InfoMessage:inform("No reading history ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN, "The reading history is empty!")
+		InfoMessage:inform("No reading history ", DINFO_DELAY, 1, MSG_WARN)
 		return nil
 	end
 

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -284,7 +284,6 @@ function FileSearcher:choose(keywords)
 	self.pagedirty = true
 	self.markerdirty = false
 
-	
 	-- if given keywords, set new result according to keywords.
 	-- Otherwise, display the previous search result.
 	if keywords then
@@ -292,7 +291,7 @@ function FileSearcher:choose(keywords)
 	end
 	-- NuPogodi, 30.09.12: immediate quit (no redraw), if empty -- there is nothing to do in empty list anyway
 	if #self.result < 1 then
-		InfoMessage:inform("No search hits found ", DINFO_NODELAY, 1, MSG_WARN)
+		InfoMessage:inform("No search hits found ", DINFO_DELAY, 1, MSG_WARN)
 		return nil
 	end
 

--- a/filesearcher.lua
+++ b/filesearcher.lua
@@ -205,15 +205,13 @@ function FileSearcher:addAllCommands()
 		"invoke search inputbox",
 		function(self)
 			local old_keywords = self.keywords
-			self.keywords = InputBox:input(G_height - 100, 100,
-"Search:", old_keywords)
+			self.keywords = InputBox:input(G_height - 100, 100, "Search:", old_keywords)
 			if self.keywords then
 				local old_data = self.result -- be sure that something is found, otherwise restore
 				local old_page, old_current = self.page, self.current
 				self:setSearchResult(self.keywords)
 				if #self.result < 1 then
-					InfoMessage:inform("No search hits ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN,
-						"The search has given no results ")
+					InfoMessage:inform("No search hits ", DINFO_DELAY, 1, MSG_WARN)
 					-- restoring the original data
 					self.result = old_data
 					self.items = #self.result
@@ -259,8 +257,7 @@ function FileSearcher:addAllCommands()
 			if InfoMessage.InfoMethod[MSG_CONFIRM] == 0 then -- silent regime
 				self:deleteFoundFile(file_to_del)
 			else
-				InfoMessage:inform("Press 'Y' to confirm ", nil, 0, MSG_CONFIRM,
-					"Press key Y to confirm deleting")
+				InfoMessage:inform("Press 'Y' to confirm ", DINFO_NODELAY, 0, MSG_CONFIRM)
 				if ReturnKey() == KEY_Y then
 					self:deleteFoundFile(file_to_del)
 				end
@@ -295,7 +292,7 @@ function FileSearcher:choose(keywords)
 	end
 	-- NuPogodi, 30.09.12: immediate quit (no redraw), if empty -- there is nothing to do in empty list anyway
 	if #self.result < 1 then
-		InfoMessage:inform("No search hits found ", DINFO_TIMEOUT_FAST, 1, MSG_WARN)
+		InfoMessage:inform("No search hits found ", DINFO_NODELAY, 1, MSG_WARN)
 		return nil
 	end
 

--- a/inputbox.lua
+++ b/inputbox.lua
@@ -603,7 +603,7 @@ function InputBox:ModeDependentCommands()
 			"calculate the result",
 			function(self)
 				if #self.input_string == 0 then
-					InfoMessage:inform("No input! ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN, "There is nothing to calculate")
+					InfoMessage:inform("No user input ", DINFO_DELAY, 1, MSG_WARN)
 				else
 					local s = self:PrepareStringToCalc()
 					if pcall(function () f = assert(loadstring("r = tostring("..s..")")) end) and pcall(f) then
@@ -620,7 +620,7 @@ function InputBox:ModeDependentCommands()
 						self.cursor:draw()
 						fb:refresh(1, self.input_start_x-5, self.input_start_y-25, self.input_slot_w, self.h-25)
 					else
-						InfoMessage:inform("Invalid input! ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+						InfoMessage:inform("Invalid user input ", DINFO_DELAY, 1, MSG_WARN)
 					end -- if pcall
 				end
 			end -- function

--- a/koptconfig.lua
+++ b/koptconfig.lua
@@ -470,7 +470,7 @@ function KOPTConfig:modBBox(koptreader)
 
 	fb.bb:invertRect( 0,y_s, G_width,1 )
 	fb.bb:invertRect( x_s,0, 1,G_height )
-	InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+	InfoMessage:inform(running_corner.." bbox ", DINFO_NODELAY, 1, MSG_WARN,
 		running_corner.." bounding box")
 	fb:refresh(1)
 
@@ -506,7 +506,7 @@ function KOPTConfig:modBBox(koptreader)
 					Debug("change top-left", bbox, "to", new_bbox)
 					running_corner = "bottom-right"
 					Screen:restoreFromSavedBB()
-					InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+					InfoMessage:inform(running_corner.." bbox ", DINFO_NODELAY, 1, MSG_WARN,
 						running_corner.." bounding box")
 					fb:refresh(1)
 					x_s = x+w
@@ -621,7 +621,7 @@ function KOPTConfig:modBBox(koptreader)
 	x,y,w,h = koptreader:getRectInScreen( new_bbox["x0"], new_bbox["y0"], new_bbox["x1"], new_bbox["y1"] )
 	fb.bb:invertRect( x,y, w,h )
 	--fb.bb:invertRect( x+1,y+1, w-2,h-2 ) -- just border?
-	InfoMessage:inform("New page bbox ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN, "New page bounding box")
+	InfoMessage:inform("New page bbox ", DINFO_DELAY, 1, MSG_WARN, "New page bounding box")
 	
 	-- restore variables changed in modBBox
 	koptreader.globalzoom = orig_globalzoom

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -302,7 +302,7 @@ function KOPTReader:drawOrCache(no, preCache)
 	else
 		if use_threads and self.precache_kc and self.precache_kc:isPreCache() == 1 and self.cache[self.cached_pagehash] then
 			Debug("How about staying here and wait?")
-			InfoMessage:inform("Rendering in background...", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+			InfoMessage:inform("Rendering in background...", DINFO_DELAY, 1, MSG_WARN)
 			return self.cached_pagehash, self.cached_offset_x, self.cached_offset_y
 		else
 			page:reflow(kc, self.render_mode)

--- a/pdfreader.lua
+++ b/pdfreader.lua
@@ -77,7 +77,7 @@ end
 -- saves all attachments on the current page in the same directory
 -- as the file itself (see extr.c utility)
 function PDFReader:saveAttachments()
-	InfoMessage:inform("Saving attachments...", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+	InfoMessage:inform("Saving attachments...", DINFO_NODELAY, 1, MSG_AUX)
 	local p = io.popen('./extr "'..self.filename..'" '..tostring(self.pageno), "r")
 	local count = p:read("*a")
 	p:close()
@@ -85,13 +85,14 @@ function PDFReader:saveAttachments()
 		-- double braces are needed because string.gsub() returns more than one value
 		count = tonumber((string.gsub(count, "[\n\r]+", "")))
 		if count == 0 then
-			InfoMessage:inform("No attachments found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+			InfoMessage:inform("No attachments found ", DINFO_DELAY, 1, MSG_WARN)
 		else
 			InfoMessage:inform(count.." attachment"..(count > 1 and "s" or "").." saved ",
-				DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+				DINFO_DELAY, 1, MSG_AUX)
 		end
 	else
-		InfoMessage:inform("Failed to save attachments ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform("Failed to save attachments ", DINFO_DELAY, 1, MSG_WARN)
 	end
+	-- needed because of inform(..DINFO_NODELAY..) above
 	self:redrawCurrentPage()
 end

--- a/reader.lua
+++ b/reader.lua
@@ -35,7 +35,7 @@ function openFile(filename)
 
 	reader = ReaderChooser:getReaderByName(filename)
 	if reader then
-		InfoMessage:inform("Opening document... ", nil, 0, MSG_AUX)
+		InfoMessage:inform("Opening document... ", DINFO_NODELAY, 0, MSG_AUX)
 		reader:preLoadSettings(filename)
 		local ok, err = reader:open(filename)
 		if ok then
@@ -47,9 +47,9 @@ function openFile(filename)
 		else
 			if err then
 				Debug("openFile(): "..err)
-				InfoMessage:inform(err:sub(1,30), DINFO_TIMEOUT_SLOW, 1, MSG_ERROR)
+				InfoMessage:inform(err:sub(1,30), DINFO_DELAY, 1, MSG_ERROR)
 			else
-				InfoMessage:inform("Error opening document! ", DINFO_TIMEOUT_SLOW, 1, MSG_ERROR)
+				InfoMessage:inform("Error opening document ", DINFO_DELAY, 1, MSG_ERROR)
 			end
 		end
 	end

--- a/screen.lua
+++ b/screen.lua
@@ -118,7 +118,7 @@ function Screen:screenshot()
 	--self:fb2bmp("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".bmp", true, "bzip2 ")
 	--self:fb2pgm("/dev/fb0", lfs.currentdir().."/screenshots/"..os.date("%Y%m%d%H%M%S")..".pgm", "bzip2 ", 4)
 	local msg = "Screenshot is ready in "
-	InfoMessage:inform(msg..string.format("%.2fs ", diff), DINFO_TIMEOUT_SLOW, 1, MSG_WARN, msg..math.ceil(diff*1000).." milliseconds")
+	InfoMessage:inform(msg..string.format("%.2fs ", diff), DINFO_DELAY, 1, MSG_WARN, msg..math.ceil(diff*1000).." milliseconds")
 end
 
 -- NuPogodi (02.07.2012): added the functions to save the fb-content in common graphic files - bmp & pgm.

--- a/unireader.lua
+++ b/unireader.lua
@@ -137,8 +137,6 @@ function UniReader:open(filename, cache_size)
 end
 
 function UniReader:init()
-	-- initialize commands
-	InfoMessage:inform("Registering fonts...", DINFO_TIMEOUT_FAST, 1, MSG_AUX)
 	self:addAllCommands()
 end
 
@@ -395,7 +393,7 @@ end
 function UniReader:startHighLightMode()
 	local t = self:getText(self.pageno)
 	if not t or #t == 0 then
-		InfoMessage:inform("No text available ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN);
+		InfoMessage:inform("No text available ", DINFO_DELAY, 1, MSG_WARN);
 		return nil
 	end
 
@@ -406,7 +404,7 @@ function UniReader:startHighLightMode()
 			end
 		end
 
-		InfoMessage:inform("No visible text ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN);
+		InfoMessage:inform("No visible text ", DINFO_DELAY, 1, MSG_WARN);
 		Debug("_findFirstWordInView none found in", t)
 
 		return nil
@@ -1839,7 +1837,7 @@ end
 function UniReader:modifyGamma(factor)
 	Debug("modifyGamma, gamma=", self.globalgamma, " factor=", factor)
 	self.globalgamma = self.globalgamma * factor;
-	InfoMessage:inform(string.format("New gamma is %.2f", self.globalgamma), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+	InfoMessage:inform(string.format("New gamma is %.2f", self.globalgamma), DINFO_NODELAY, 1, MSG_AUX)
 	self:redrawCurrentPage()
 end
 
@@ -2057,7 +2055,7 @@ function UniReader:showToc()
 	end
 
 	if #self.toc == 0 then
-		return InfoMessage:inform("No Table of Contents ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		return InfoMessage:inform("No Table of Contents ", DINFO_DELAY, 1, MSG_WARN)
 	end
 
 	local toc_curitem = self:findTOCpos()
@@ -2075,7 +2073,7 @@ function UniReader:showToc()
 			local toc_entry = self.toc[self.toc_curidx_to_x[ret_code]]
 			local pagenum = toc_entry.page
 			if pagenum < 1 or pagenum > self.doc:getPages() then
-				InfoMessage:inform("External links unsupported ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("External links unsupported ", DINFO_DELAY, 1, MSG_WARN)
 				toc_curitem = ret_code
 			else
 				return self:gotoTocEntry(toc_entry)
@@ -2114,7 +2112,7 @@ function UniReader:showJumpHist()
 	end
 
 	if #menu_items == 0 then
-		InfoMessage:inform("No jump history found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform("No jump history found ", DINFO_DELAY, 1, MSG_WARN)
 	else
 		-- if cur points to head, draw entry for current page
 		if self.jump_history.cur > #self.jump_history then
@@ -2151,7 +2149,7 @@ function UniReader:showBookMarks()
 			"p."..v.page.." "..v.notes.." @ "..v.datetime)
 	end
 	if #menu_items == 0 then
-		return InfoMessage:inform("No bookmarks found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		return InfoMessage:inform("No bookmarks found ", DINFO_DELAY, 1, MSG_WARN)
 	end
 	while true do
 		bm_menu = SelectMenu:new{
@@ -2214,7 +2212,7 @@ function UniReader:showHighLight()
 	end
 
 	if #menu_items == 0 then
-		return InfoMessage:inform("No HighLights found ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		return InfoMessage:inform("No HighLights found ", DINFO_DELAY, 1, MSG_WARN)
 	end
 
 	while true do
@@ -2321,14 +2319,14 @@ function UniReader:searchHighLight(search)
 
 	self:goto(self.pageno) -- show highlights, remove input
 	if found > 0 then
-		InfoMessage:inform( found.." hits '"..search.."' page "..self.pageno, DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform( found.." hits '"..search.."' page "..self.pageno, DINFO_DELAY, 1, MSG_WARN)
 		self.last_search = {
 			pageno = self.pageno,
 			search = search,
 			hits = found,
 		}
 	else
-		InfoMessage:inform( "'"..search.."' not found in document ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		InfoMessage:inform( "'"..search.."' not found in document ", DINFO_DELAY, 1, MSG_WARN)
 	end
 
 	self.highlight = old_highlight -- will not remove search highlights until page refresh
@@ -2517,7 +2515,7 @@ function UniReader:gotoPrevNextTocEntry(direction)
 		self:fillToc()
 	end
 	if #self.toc == 0 then
-		return InfoMessage:inform("No Table of Contents ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+		return InfoMessage:inform("No Table of Contents ", DINFO_DELAY, 1, MSG_WARN)
 	end
 
 	local numpages, last_toc_page, penul_toc_page = self.doc:getPages(), 1, 1
@@ -2591,7 +2589,7 @@ function UniReader:addAllCommands()
 		function(unireader,keydef)
 			local is_zoom_out = (keydef.keycode == KEY_PGBCK or keydef.keycode == KEY_LPGBCK)
 			local new_zoom = unireader.globalzoom_orig * (1 + (is_zoom_out and -1 or 1)*unireader.step_manual_zoom/100)
-			InfoMessage:inform(string.format("New zoom is %.2f ", new_zoom), DINFO_TIMEOUT_FAST, 1, MSG_WARN)
+			InfoMessage:inform(string.format("New zoom is %.2f ", new_zoom), DINFO_NODELAY, 1, MSG_WARN)
 			unireader:setGlobalZoom(new_zoom)
 		end)
 	-- NuPogodi, 03.09.12: make zoom step user-configurable
@@ -2603,15 +2601,15 @@ function UniReader:addAllCommands()
 			if keydef.keycode == KEY_PGFWD or keydef.keycode == KEY_LPGFWD then
 				unireader.step_manual_zoom = unireader.step_manual_zoom * 2
 				self.settings:saveSetting("step_manual_zoom", self.step_manual_zoom)
-				InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("New zoom step: "..unireader.step_manual_zoom.."% ", DINFO_DELAY, 1, MSG_WARN)
 			else
 				local minstep = 1
 				if unireader.step_manual_zoom > 2*minstep then
 					unireader.step_manual_zoom = unireader.step_manual_zoom / 2
 					self.settings:saveSetting("step_manual_zoom", self.step_manual_zoom)
-					InfoMessage:inform("New zoom step is "..unireader.step_manual_zoom.."%. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("New zoom step: "..unireader.step_manual_zoom.."% ", DINFO_DELAY, 1, MSG_WARN)
 				else
-					InfoMessage:inform("Minimum zoom step is "..minstep.."%. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("Min zoom step: "..minstep.."% ", DINFO_DELAY, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -2631,7 +2629,7 @@ function UniReader:addAllCommands()
 				unireader.jump_history.cur = prev_jump_no
 				unireader:goto(unireader.jump_history[prev_jump_no].page, true)
 			else
-				InfoMessage:inform("Already first jump ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Already first jump ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end)
 	self.commands:add(KEY_BACK,MOD_SHIFT,"Back",
@@ -2646,7 +2644,7 @@ function UniReader:addAllCommands()
 					unireader.jump_history.cur = unireader.jump_history.cur + 1
 				end
 			else
-				InfoMessage:inform("Already last jump ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Already last jump ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end)
 	self.commands:addGroup("vol-/+",{Keydef:new(KEY_VPLUS,nil),Keydef:new(KEY_VMINUS,nil)},
@@ -2760,7 +2758,7 @@ function UniReader:addAllCommands()
 		"toggle battery level logging",
 		function(unireader)
 			G_battery_logging = not G_battery_logging
-			InfoMessage:inform("Battery logging "..(G_battery_logging and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Battery logging "..(G_battery_logging and "on " or "off "), DINFO_DELAY, 1, MSG_AUX)
 			G_reader_settings:saveSetting("G_battery_logging", G_battery_logging)
 		end)
 	self.commands:add(KEY_T,nil,"T",
@@ -2778,9 +2776,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			ok = unireader:addBookmark(self.pageno)
 			if not ok then
-				InfoMessage:inform("Page already marked ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Page already marked ", DINFO_DELAY, 1, MSG_WARN)
 			else
-				InfoMessage:inform("Page marked ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("Page marked ", DINFO_DELAY, 1, MSG_WARN)
 			end
 		end)
 	self.commands:addGroup(MOD_ALT.."K/L",{
@@ -2835,7 +2833,7 @@ function UniReader:addAllCommands()
 		"toggle showing page overlap areas",
 		function(unireader)
 			unireader.show_overlap_enable = not unireader.show_overlap_enable
-			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Turning overlap "..(unireader.show_overlap_enable and "on " or "off "), DINFO_DELAY, 1, MSG_AUX)
 			self.settings:saveSetting("show_overlap_enable", unireader.show_overlap_enable)
 			self:redrawCurrentPage()
 		end)
@@ -2844,7 +2842,7 @@ function UniReader:addAllCommands()
 		"toggle page-buttons mode: viewport/page",
 		function(unireader)
 			unireader.page_mode_enable = not unireader.page_mode_enable
-			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page " or "viewport "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Page-buttons move "..(unireader.page_mode_enable and "page " or "viewport "), DINFO_DELAY, 1, MSG_AUX)
 			self.settings:saveSetting("page_mode_enable", unireader.page_mode_enable)
 		end)
 
@@ -2852,7 +2850,7 @@ function UniReader:addAllCommands()
 		"toggle right-to-left mode on/off",
 		function(unireader)
 			unireader.rtl_mode_enable = not unireader.rtl_mode_enable
-			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Right-To-Left mode "..(unireader.rtl_mode_enable and "on " or "off "), DINFO_DELAY, 1, MSG_AUX)
 			self.settings:saveSetting("rtl_mode_enable", unireader.rtl_mode_enable)
 		end)
 
@@ -2860,7 +2858,7 @@ function UniReader:addAllCommands()
 		"align the viewport to top/bottom",
 		function(unireader)
 			unireader.comics_mode_enable = not unireader.comics_mode_enable
-			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "BOTTOM " or "TOP "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Align the viewport to "..(unireader.comics_mode_enable and "bottom " or "top "), DINFO_DELAY, 1, MSG_AUX)
 			self.settings:saveSetting("comics_mode_enable", unireader.comics_mode_enable)
 		end)
 
@@ -2868,17 +2866,17 @@ function UniReader:addAllCommands()
 		"reset default reader preferences",
 		function(unireader)
 			G_reader_settings:delSetting("reader_preferences")
-			InfoMessage:inform("Reseting reader preferences", DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+			InfoMessage:inform("Reader preferences reset", DINFO_DELAY, 1, MSG_AUX)
 		end)
 	
 	self.commands:add(KEY_C, MOD_ALT, "C",
 		"clear reader association with this doc",
 		function(unireader)
 			if self.settings:readSetting("reader_association") == "N/A" then
-				InfoMessage:inform("No reader associated", DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+				InfoMessage:inform("No reader associated ", DINFO_DELAY, 1, MSG_AUX)
 			else
 				self.settings:saveSetting("reader_association", "N/A")
-				InfoMessage:inform("Clearing reader association", DINFO_TIMEOUT_SLOW, 1, MSG_AUX)
+				InfoMessage:inform("Reader association cleared", DINFO_DELAY, 1, MSG_AUX)
 			end
 		end)
 
@@ -2929,20 +2927,20 @@ function UniReader:addAllCommands()
 			unireader.bbox.enabled = true
 			Debug("bbox", unireader.pageno, unireader.bbox)
 			unireader.globalzoom_mode = unireader.ZOOM_FIT_TO_CONTENT -- use bbox
-			InfoMessage:inform("Manual crop setting saved. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop setting saved ", DINFO_DELAY, 1, MSG_WARN)
 		end)
 	self.commands:add(KEY_Z,MOD_SHIFT,"Z",
 		"reset crop",
 		function(unireader)
 			unireader.bbox[unireader.pageno] = nil;
-			InfoMessage:inform("Manual crop setting removed. ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop setting removed ", DINFO_DELAY, 1, MSG_WARN)
 			Debug("bbox remove", unireader.pageno, unireader.bbox);
 		end)
 	self.commands:add(KEY_Z,MOD_ALT,"Z",
 		"toggle crop mode",
 		function(unireader)
 			unireader.bbox.enabled = not unireader.bbox.enabled;
-			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_TIMEOUT_FAST, 1, MSG_WARN)
+			InfoMessage:inform("Manual crop "..(unireader.bbox.enabled and "enabled " or "disabled "), DINFO_DELAY, 1, MSG_WARN)
 			Debug("bbox override", unireader.bbox.enabled);
 		end)
 	self.commands:add(KEY_X,nil,"X",
@@ -2971,7 +2969,7 @@ function UniReader:addAllCommands()
 
 			fb.bb:invertRect( 0,y_s, G_width,1 )
 			fb.bb:invertRect( x_s,0, 1,G_height )
-			InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+			InfoMessage:inform(running_corner.." bbox ", DINFO_NODELAY, 1, MSG_WARN,
 				running_corner.." bounding box")
 			fb:refresh(1)
 
@@ -3007,7 +3005,7 @@ function UniReader:addAllCommands()
 							Debug("change top-left", bbox, "to", new_bbox)
 							running_corner = "bottom-right"
 							Screen:restoreFromSavedBB()
-							InfoMessage:inform(running_corner.." bbox ", nil, 1, MSG_WARN,
+							InfoMessage:inform(running_corner.." bbox ", DINFO_NODELAY, 1, MSG_WARN,
 								running_corner.." bounding box")
 							fb:refresh(1)
 							x_s = x+w
@@ -3123,7 +3121,7 @@ function UniReader:addAllCommands()
 			x,y,w,h = unireader:getRectInScreen( new_bbox["x0"], new_bbox["y0"], new_bbox["x1"], new_bbox["y1"] )
 			fb.bb:invertRect( x,y, w,h )
 			--fb.bb:invertRect( x+1,y+1, w-2,h-2 ) -- just border?
-			InfoMessage:inform("New page bbox ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN, "New page bounding box")
+			InfoMessage:inform("New page bbox ", DINFO_DELAY, 1, MSG_WARN, "New page bounding box")
 			self:redrawCurrentPage()
 
 			self.rcount = self.rcountmax -- force next full refresh
@@ -3330,17 +3328,17 @@ function UniReader:addAllCommands()
 				unireader.shift_x = unireader.shift_x * 2
 				if unireader.shift_x >= G_width then
 					unireader.shift_x = G_width
-					InfoMessage:inform("Maximum X-panning step is "..G_width..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("Max X-panning step: "..G_width, DINFO_DELAY, 1, MSG_WARN)
 				end
 				self.settings:saveSetting("shift_x", self.shift_x)
-				InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("New X-panning step: "..unireader.shift_x, DINFO_DELAY, 1, MSG_WARN)
 			else
 				if unireader.shift_x >= 2*minstep then
 					unireader.shift_x = math.ceil(unireader.shift_x / 2)
 					self.settings:saveSetting("shift_x", self.shift_x)
-					InfoMessage:inform("New X-panning step is "..unireader.shift_x..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("New X-panning step: "..unireader.shift_x, DINFO_DELAY, 1, MSG_WARN)
 				else
-					InfoMessage:inform("Minimum X-panning step is "..minstep..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("Min X-panning step: "..minstep, DINFO_DELAY, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -3353,17 +3351,17 @@ function UniReader:addAllCommands()
 				unireader.shift_y = unireader.shift_y * 2
 				if unireader.shift_y >= G_height then
 					unireader.shift_y = G_height
-					InfoMessage:inform("Maximum Y-panning step is "..G_height..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("Max Y-panning step: "..G_height, DINFO_DELAY, 1, MSG_WARN)
 				end
 				self.settings:saveSetting("shift_y", self.shift_y)
-				InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("New Y-panning step: "..unireader.shift_y, DINFO_DELAY, 1, MSG_WARN)
 			else
 				if unireader.shift_y >= 2*minstep then
 					unireader.shift_y = math.ceil(unireader.shift_y / 2)
 					self.settings:saveSetting("shift_y", self.shift_y)
-					InfoMessage:inform("New Y-panning step is "..unireader.shift_y..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("New Y-panning step: "..unireader.shift_y, DINFO_DELAY, 1, MSG_WARN)
 				else
-					InfoMessage:inform("Minimum Y-panning step is "..minstep..". ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("Min Y-panning step is "..minstep, DINFO_DELAY, 1, MSG_WARN)
 				end
 			end
 		end)
@@ -3403,7 +3401,7 @@ function UniReader:addAllCommands()
 		"show/hide link underlines",
 		function(unireader)
 			unireader.show_links_enable = not unireader.show_links_enable
-			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "ON " or "OFF "), DINFO_TIMEOUT_FAST, 1, MSG_AUX)
+			InfoMessage:inform("Link underlines "..(unireader.show_links_enable and "on " or "off "), DINFO_DELAY, 1, MSG_AUX)
 			self.settings:saveSetting("show_links_enable", unireader.show_links_enable)
 			self:redrawCurrentPage()
 		end
@@ -3413,7 +3411,7 @@ function UniReader:addAllCommands()
 		function(unireader)
 			local links = unireader:getPageLinks( unireader.pageno )
 			if links == nil or next(links) == nil then
-				InfoMessage:inform("No links on this page ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+				InfoMessage:inform("No links on this page ", DINFO_DELAY, 1, MSG_WARN)
 			else
 				Debug("shortcuts",SelectMenu.item_shortcuts)
 
@@ -3446,7 +3444,7 @@ function UniReader:addAllCommands()
 				end
 
 				if page_links == 0 then
-					InfoMessage:inform("No page links on this page ", DINFO_TIMEOUT_SLOW, 1, MSG_WARN)
+					InfoMessage:inform("No page links on this page ", DINFO_DELAY, 1, MSG_WARN)
 					return
 				end
 


### PR DESCRIPTION
Ok, this is the Final Solution, hopefully :)
As Linus says, how many times we can get it wrong, really --- we should have run out of wrong ideas by now :)

This patch changes the second argument of InfoMessage:inform() function to be either DINFO_DELAY or DINFO_NODELAY with the following semantics:

DINFO_DELAY - display the message and delay DINFO_DELAY ms before returning. Save and restore the screen content. This is useful when the message is only conveying information and nothing has changed on the screen. For example, this is ideal for informing the user about options toggled on/off. I repeat: delaying after the display of toggle message is THE RIGHT THING TO DO (I didn't understand this until now, hence all those earlier unnecessary commits...)

DINFO_NODELAY - display the message and return immediately without saving/restoring the screen content. This is useful when there is work after the call that will change the screen content anyway and will have to take care of it. Note that if you follow a DINFO_NODELAY call with a DINFO_DELAY one then you have to manually refresh the screen (see the usage in Alt-S command handler in pdfreader.lua)

On the emulator DINFO_NODELAY is delayed by a small amount in order to simulate Kindle's behaviour (and make the message noticeable). But the semantics of DINFO_NODELAY (notably the NOT saving/restoring screen content) is exactly the same on the emulator and on Kindle, so no extra "redraw page" calls are needed specifically for Kindle but not on emulator.

The "ON" and "OFF" were changed to "on" and "off" and some other words lowercased to make it easier on the TTS to pronounce them (otherwise it thinks they are abbreviations). Of course I know that we could have passed a separate tts_text argument but there is nothing wrong with the lowercase "on" and "off" (I like them better) so I didn't do that.
