### PR TITLE
Implements Kindle screen rotate on emulator and forces portrait mode on doc close

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -116,10 +116,13 @@ end
 G_screen_saver_mode = false
 G_charging_mode = false
 fb = einkfb.open("/dev/fb0")
-G_width, G_height = fb:getSize()
 -- read current rotation mode
 Screen:updateRotationMode()
 Screen.native_rotation_mode = Screen.cur_rotation_mode
+
+-- force portrait mode
+Screen:setRotationMode(0)
+G_width, G_height = fb:getSize()
 
 -- set up reader's setting: font
 G_reader_settings = DocSettings:open(".reader")

--- a/screen.lua
+++ b/screen.lua
@@ -47,6 +47,19 @@ Screen = {
 	saved_bb = nil,
 }
 
+function Screen:setRotationMode(mode)
+	if mode < 0 or mode > 3 then
+		Debug("Illegal mode parameter to Screen:setRotatonMode()!")
+		return
+	end
+
+	self.cur_rotation_mode = mode
+	-- you have to reopen framebuffer after rotate
+	fb:setOrientation(self.cur_rotation_mode)
+	fb:close()
+	fb = einkfb.open("/dev/fb0")
+end
+
 -- @orien: 1 for clockwise rotate, -1 for anti-clockwise
 -- Remember to reread screen resolution after this function call
 function Screen:screenRotate(orien)

--- a/unireader.lua
+++ b/unireader.lua
@@ -1874,6 +1874,14 @@ function UniReader:screenRotate(orien)
 	self:clearCache()
 end
 
+function UniReader:setRotationMode(mode)
+	Screen:setRotationMode(mode)
+	-- update global width and height variable
+	G_width, G_height = fb:getSize()
+	self:clearCache()
+end
+
+
 function UniReader:cleanUpTocTitle(title)
 	return (title:gsub("\13", ""))
 end
@@ -2485,6 +2493,7 @@ function UniReader:inputLoop()
 	self.toc_cview = nil
 	self.toc_curidx_to_x = nil
 	self.show_overlap = 0
+	self:setRotationMode(0)
 	self:setDefaults()
 	if self.doc ~= nil then
 		self.doc:close()


### PR DESCRIPTION
Although I said “don’t look at me” in #573, it turned out to be pretty simple. This is not a full implementation - both J and K will just flip back and forth to landscape/portrait. I don’t think full implementation is necessary for development (who’d want to read upside down?), and I’m lazy by nature, so if anyone wants to do all modes - be my guest.

Second commit contains changes that will force portrait mode on closing documents. I tested it on both emu and Kindle, and it appears to work fine (at least better than without the patch. Try rotating the screen in a version prior to this PR, and then press Home. You’ll see what I mean). But, given my history of missing things, please do test yourself. I uploaded latest build [here](https://github.com/kai771/kindlepdfviewer/downloads), so it should be easy for anyone to test and report bugs.
