### PR TITLE
update k2pdfopt to version 1.62

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ endif
 
 # standard includes
 KPDFREADER_CFLAGS=$(CFLAGS) -I$(LUADIR)/src -I$(MUPDFDIR)/
-K2PDFOPT_CFLAGS=-I$(MUPDFDIR)/ -I$(DJVUDIR)/ -I$(K2PDFOPTLIBDIR)/
+K2PDFOPT_CFLAGS=-I$(K2PDFOPTLIBDIR)/willuslib -I$(K2PDFOPTLIBDIR)/k2pdfoptlib -I$(K2PDFOPTLIBDIR)/
 
 # enable tracing output:
 

--- a/koptcontext.h
+++ b/koptcontext.h
@@ -21,7 +21,7 @@
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
-#include "k2pdfopt.h"
+#include "koptreflow.h"
 
 int luaopen_koptcontext(lua_State *L);
 #endif

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -326,7 +326,7 @@ function KOPTReader:drawOrCache(no, preCache)
 			local nsecs, nusecs = util.gettime()
 			local dur = (nsecs - secs) * 1000000 + nusecs - usecs
 			Debug("Reflow duration:", dur)
-			self:logReflowDuration(no, dur)
+			--self:logReflowDuration(no, dur)
 			return self:writeToCache(kc, page, pagehash, preCache)
 		end
 	end


### PR DESCRIPTION
This patch updated k2pdfopt to the latest version 1.62 and fixed bug of segmentation fault in multi-thread mode reported in #592.
