### PR TITLE
bugfix: using bbox of previous document

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -2500,6 +2500,7 @@ function UniReader:inputLoop()
 	self.toc_xview = nil
 	self.toc_cview = nil
 	self.toc_curidx_to_x = nil
+	self.bbox.enabled = false
 	self.show_overlap = 0
 	self:setRotationMode(0)
 	self:setDefaults()


### PR DESCRIPTION
If you open a document, manually set bbox, then close it and open another one without bbox, manually set bbox of the previous document is used, which is annoying. This fixes it.
