### PR TITLE
bugfix: FileChooser crashes when closing landscape document

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -215,7 +215,7 @@ function FileChooser:choose(ypos, height)
 		local cface = Font:getFace("cfont", 22)
 
 		if self.pagedirty then
-			fb.bb:paintRect(0, ypos, fb.bb:getWidth(), height, 0)
+			fb.bb:paintRect(0, ypos, fb.bb:getWidth(), fb.bb:getHeight(), 0)
 			local c
 			for c = 1, self.perpage do
 				local i = (self.page - 1) * self.perpage + c
@@ -254,7 +254,7 @@ function FileChooser:choose(ypos, height)
 		end
 
 		if self.pagedirty then
-			fb:refresh(0, 0, ypos, fb.bb:getWidth(), height)
+			fb:refresh(0, 0, ypos, fb.bb:getWidth(), fb.bb:getHeight())
 			self.pagedirty = false
 		end
 


### PR DESCRIPTION
Yes, we already fixed that forcing portrait mode on KPV start, and document close. However, this is a fix that will prevent the crash if we don't force portrait. I'm not suggesting that we stop forcing portrait - I think we all agreed that FileChooser in landscape mode on K3 is not very usable. But, this might be handy on Touch or KPW (we'll see about that later), so it should be usable should we need it. To test this, you need to comment out `self:setRotationMode(0)` line in UniReader:inputLoop() in unireader.lua, thus removing forcing of portrait on document close.
