### PR TITLE
Added InfoMessage:drawTopMsg() method

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -625,9 +625,9 @@ function CREReader:adjustCreReaderCommands()
 		function(self)
 			ok = self:addBookmark(self.doc:getXPointer())
 			if not ok then
-				InfoMessage:inform("Page already marked ", DINFO_DELAY, 1, MSG_WARN)
+				InfoMessage:drawTopMsg("Bookmark already exists")
 			else
-				InfoMessage:inform("Page marked ", DINFO_DELAY, 1, MSG_WARN)
+				InfoMessage:drawTopMsg("Bookmark added")
 			end
 		end
 	)

--- a/dialog.lua
+++ b/dialog.lua
@@ -261,3 +261,11 @@ function InfoMessage:saveInfoMessageSettings()
 	G_reader_settings:saveSetting("sound_volume", self.SoundVolume-1)
 	G_reader_settings:saveSetting("tts_speed", self.TTSspeed)
 end
+
+function InfoMessage:drawTopMsg(msg)
+	local face = Font:getFace("rifont", 18)
+	local len = sizeUtf8Text(0, G_width, face, msg, true).x + 20
+	fb.bb:paintRect(0, 0, len, 15+6*2, 4)
+	renderUtf8Text(fb.bb, 10, 15+6, face, msg, true)
+	fb:refresh(1)
+end

--- a/unireader.lua
+++ b/unireader.lua
@@ -2815,9 +2815,9 @@ function UniReader:addAllCommands()
 		function(unireader)
 			ok = unireader:addBookmark(self.pageno)
 			if not ok then
-				InfoMessage:inform("Page already marked ", DINFO_DELAY, 1, MSG_WARN)
+				InfoMessage:drawTopMsg("Bookmark already exists")
 			else
-				InfoMessage:inform("Page marked ", DINFO_DELAY, 1, MSG_WARN)
+				InfoMessage:drawTopMsg("Bookmark added")
 			end
 		end)
 	self.commands:addGroup(MOD_ALT.."K/L",{


### PR DESCRIPTION
Displaying a pop-up window for operations like adding a bookmark seems a bit of an overkill for simple messages like "Bookmark added" or "Bookmark already exists". Therefore, based on the suggestion by @dracodoc (see his feature request in #538)I have implemented a method `InfoMessage:drawTopMsg()` for this purpose which just renders the text in the top left corner on a gray background of auto-calculated appropriate width.

Does not support TTS (do we really need it? I don't think so.)
