### PR TITLE
Cleanup the forcing of portrait mode and make FileChooser work in landscape mode

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -202,7 +202,11 @@ function FileChooser:setPath(newPath)
 	end
 end
 
-function FileChooser:choose(ypos, height)
+function FileChooser:choose()
+	local ypos = 0
+	local width, height = G_width, G_height
+	local wlen = width - 2*self.margin_H
+
 	self.perpage = math.floor(height / self.spacing) - 2
 	self.pagedirty = true
 	self.markerdirty = false
@@ -215,7 +219,7 @@ function FileChooser:choose(ypos, height)
 		local cface = Font:getFace("cfont", 22)
 
 		if self.pagedirty then
-			fb.bb:paintRect(0, ypos, fb.bb:getWidth(), fb.bb:getHeight(), 0)
+			fb.bb:paintRect(0, ypos, width, height, 0)
 			local c
 			for c = 1, self.perpage do
 				local i = (self.page - 1) * self.perpage + c
@@ -241,20 +245,20 @@ function FileChooser:choose(ypos, height)
 			local ymarker = ypos + 8 + self.title_H
 			if not self.pagedirty then
 				if self.oldcurrent > 0 then
-					fb.bb:paintRect(self.margin_H, ymarker+self.spacing*self.oldcurrent, fb.bb:getWidth()-2*self.margin_H, 3, 0)
-					fb:refresh(1, self.margin_H, ymarker+self.spacing*self.oldcurrent, fb.bb:getWidth() - 2*self.margin_H, 3)
+					fb.bb:paintRect(self.margin_H, ymarker+self.spacing*self.oldcurrent, wlen, 3, 0)
+					fb:refresh(1, self.margin_H, ymarker+self.spacing*self.oldcurrent, wlen, 3)
 				end
 			end
-			fb.bb:paintRect(self.margin_H, ymarker+self.spacing*self.current, fb.bb:getWidth()-2*self.margin_H, 3, 15)
+			fb.bb:paintRect(self.margin_H, ymarker+self.spacing*self.current, wlen, 3, 15)
 			if not self.pagedirty then
-				fb:refresh(1, self.margin_H, ymarker+self.spacing*self.current, fb.bb:getWidth()-2*self.margin_H, 3)
+				fb:refresh(1, self.margin_H, ymarker+self.spacing*self.current, wlen, 3)
 			end
 			self.oldcurrent = self.current
 			self.markerdirty = false
 		end
 
 		if self.pagedirty then
-			fb:refresh(0, 0, ypos, fb.bb:getWidth(), fb.bb:getHeight())
+			fb:refresh(0, 0, ypos, width, height)
 			self.pagedirty = false
 		end
 

--- a/filechooser.lua
+++ b/filechooser.lua
@@ -204,10 +204,7 @@ end
 
 function FileChooser:choose()
 	local ypos = 0
-	local width, height = G_width, G_height
-	local wlen = width - 2*self.margin_H
 
-	self.perpage = math.floor(height / self.spacing) - 2
 	self.pagedirty = true
 	self.markerdirty = false
 
@@ -217,9 +214,11 @@ function FileChooser:choose()
 		local tface = Font:getFace("tfont", 25)
 		local fface = Font:getFace("ffont", 16)
 		local cface = Font:getFace("cfont", 22)
+		local wlen = G_width - 2*self.margin_H
+		self.perpage = math.floor(G_height / self.spacing) - 2
 
 		if self.pagedirty then
-			fb.bb:paintRect(0, ypos, width, height, 0)
+			fb.bb:paintRect(0, ypos, G_width, G_height, 0)
 			local c
 			for c = 1, self.perpage do
 				local i = (self.page - 1) * self.perpage + c
@@ -258,7 +257,7 @@ function FileChooser:choose()
 		end
 
 		if self.pagedirty then
-			fb:refresh(0, 0, ypos, width, height)
+			fb:refresh(0, 0, ypos, G_width, G_height)
 			self.pagedirty = false
 		end
 

--- a/reader.lua
+++ b/reader.lua
@@ -159,7 +159,7 @@ CREReader:init()
 local patharg = G_reader_settings:readSetting("lastfile")
 if ARGV[argidx] and lfs.attributes(ARGV[argidx], "mode") == "directory" then
 	FileChooser:setPath(ARGV[argidx])
-	FileChooser:choose(0, G_height)
+	FileChooser:choose()
 elseif ARGV[argidx] and lfs.attributes(ARGV[argidx], "mode") == "file" then
 	openFile(ARGV[argidx])
 elseif patharg and lfs.attributes(patharg, "mode") == "file" then

--- a/reader.lua
+++ b/reader.lua
@@ -122,7 +122,6 @@ Screen.native_rotation_mode = Screen.cur_rotation_mode
 
 -- force portrait mode
 Screen:setRotationMode(0)
-G_width, G_height = fb:getSize()
 
 -- set up reader's setting: font
 G_reader_settings = DocSettings:open(".reader")

--- a/screen.lua
+++ b/screen.lua
@@ -58,6 +58,7 @@ function Screen:setRotationMode(mode)
 	fb:setOrientation(self.cur_rotation_mode)
 	fb:close()
 	fb = einkfb.open("/dev/fb0")
+	G_width, G_height = fb:getSize()
 end
 
 -- @orien: 1 for clockwise rotate, -1 for anti-clockwise

--- a/unireader.lua
+++ b/unireader.lua
@@ -1893,14 +1893,6 @@ function UniReader:screenRotate(orien)
 	self:clearCache()
 end
 
-function UniReader:setRotationMode(mode)
-	Screen:setRotationMode(mode)
-	-- update global width and height variable
-	G_width, G_height = fb:getSize()
-	self:clearCache()
-end
-
-
 function UniReader:cleanUpTocTitle(title)
 	return (title:gsub("\13", ""))
 end
@@ -2512,7 +2504,7 @@ function UniReader:inputLoop()
 	self.toc_cview = nil
 	self.toc_curidx_to_x = nil
 	self.show_overlap = 0
-	self:setRotationMode(0)
+	Screen:setRotationMode(0)
 	self:setDefaults()
 	if self.doc ~= nil then
 		self.doc:close()


### PR DESCRIPTION
1. Move the setting of G_width/G_height inside the function Screen:setRotationMode()
2. Don't call self:clearCache() twice on closing the document (once is enough).
3. Get rid of UniReader:setRotationMode() method because Screen:setRotationMode() is enough, as there is nothing reader- or document-specific in this function.
4. Enhance FileChooser:choose() to work in both portrait and landscape modes. Namely, I removed the assumption that G_width and G_height retain the values they had upon the entry to this function.
