### PR TITLE
Support deleting bookmarks in crengine

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -303,6 +303,8 @@ end
 
 function CREReader:showBookMarks()
 	local menu_items = {}
+	local ret_code, item_no = -1, -1
+
 	-- build menu items
 	for k,v in ipairs(self.bookmarks) do
 		table.insert(menu_items,
@@ -310,17 +312,25 @@ function CREReader:showBookMarks()
 			.." "..v.notes.." @ "..v.datetime)
 	end
 	if #menu_items == 0 then
-		InfoMessage:inform("No bookmark found ", DINFO_DELAY, 1, MSG_WARN)
-	else
+		return InfoMessage:inform("No bookmark found ", DINFO_DELAY, 1, MSG_WARN)
+	end
+	while true do
 		local bkmk_menu = SelectMenu:new{
-			menu_title = "Bookmarks",
+			menu_title = "Bookmarks ("..tostring(#menu_items).." items)",
 			item_array = menu_items,
+			deletable = true,
 		}
-		item_no = bkmk_menu:choose(0, G_height)
-		if item_no then
-			self:goto(self.bookmarks[item_no].page, nil, "xpointer")
-		else
-			self:redrawCurrentPage()
+		ret_code, item_no = bkmk_menu:choose(0, G_height)
+		if ret_code then -- normal item selection
+			return self:goto(self.bookmarks[ret_code].page, nil, "xpointer")
+		elseif item_no then -- delete item
+			table.remove(menu_items, item_no)
+			table.remove(self.bookmarks, item_no)
+			if #menu_items == 0 then
+				return self:redrawCurrentPage()
+			end
+		else -- return via Back
+			return self:redrawCurrentPage()
 		end
 	end
 end

--- a/unireader.lua
+++ b/unireader.lua
@@ -2181,7 +2181,7 @@ function UniReader:showBookMarks()
 		return InfoMessage:inform("No bookmarks found ", DINFO_DELAY, 1, MSG_WARN)
 	end
 	while true do
-		bm_menu = SelectMenu:new{
+		local bm_menu = SelectMenu:new{
 			menu_title = "Bookmarks ("..tostring(#menu_items).." items)",
 			item_array = menu_items,
 			deletable = true,


### PR DESCRIPTION
1. Add support for deleting bookmarks in ebooks (crengine) as requested in #615. Also, display the number of bookmarks in the title of the bookmarks list dialog (as in UniReader:showBookMarks()).
2. Make the `bm_menu` variable in `UniReader:showBookMarks()` local. We shouldn't be overwriting a [potential] global `bm_menu` in there.
