### PR TITLE
Restore full File Manager functionality to KPV

### DIFF
--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -144,7 +144,8 @@ function FileInfo:init(path, fname)
 			table.insert(self.result, {dir = "Last read", name = "Never"})
 		else
 			table.insert(self.result, {dir = "Last read", name = self:FileCreated(history, "change")})
-			local file_type = string.lower(string.match(self.pathfile, ".+%.([^.]+)"))
+			local ext = string.match(self.pathfile, ".+%.([^.]+)")
+			local file_type = ext and ext:lower() or "txt"
 			local to_search, add, factor = "[\"last_percent\"]", "%", 100
 			if ReaderChooser:getReaderByType(file_type) ~= CREReader then
 				to_search = "[\"last_page\"]"

--- a/reader.lua
+++ b/reader.lua
@@ -30,10 +30,7 @@ require "readerchooser"
 require "defaults"
 
 function openFile(filename)
-	local file_type = string.lower(string.match(filename, ".+%.([^.]+)"))
-	local reader = nil
-
-	reader = ReaderChooser:getReaderByName(filename)
+	local reader = ReaderChooser:getReaderByName(filename)
 	if reader then
 		InfoMessage:inform("Opening document... ", DINFO_NODELAY, 0, MSG_AUX)
 		reader:preLoadSettings(filename)

--- a/readerchooser.lua
+++ b/readerchooser.lua
@@ -72,12 +72,17 @@ function ReaderChooser:getReaderByType(ftype)
 	if #readers >= 1 then
 		return registry[readers[1]][1]
 	else
-		return nil
+		if FileChooser.filemanager_expert_mode  > FileChooser.BEGINNERS_MODE then
+			return CREReader
+		else
+			return nil
+		end
 	end
 end
 
 function ReaderChooser:getReaderByName(filename)
-	local file_type = string.lower(string.match(filename, ".+%.([^.]+)"))
+	local ext = string.match(filename, ".+%.([^.]+)")
+	local file_type = ext and ext:lower() or "txt"
 	local readers = GetRegisteredReaders(file_type)
 	if #readers > 1 then -- more than one reader are registered with this file type
 		local file_settings = DocSettings:open(filename)
@@ -121,7 +126,11 @@ function ReaderChooser:getReaderByName(filename)
 	elseif #readers == 1 then
 		return registry[readers[1]][1]
 	else
-		return nil
+		if FileChooser.filemanager_expert_mode  > FileChooser.BEGINNERS_MODE then
+			return CREReader
+		else
+			return nil
+		end
 	end
 end
 

--- a/settings.lua
+++ b/settings.lua
@@ -57,7 +57,8 @@ function DocSettings:open(docfile)
 			end
 
 			if stored.highlight ~= nil then
-				local file_type = string.lower(string.match(docfile, ".+%.([^.]+)"))
+				local ext = string.match(docfile, ".+%.([^.]+)")
+				local file_type = ext and ext:lower() or "txt"
 				if file_type == "djvu" then
 					stored.highlight.to_fix = {"djvu invert y axle"}
 				end

--- a/settings.lua
+++ b/settings.lua
@@ -57,8 +57,7 @@ function DocSettings:open(docfile)
 			end
 
 			if stored.highlight ~= nil then
-				local ext = string.match(docfile, ".+%.([^.]+)")
-				local file_type = ext and ext:lower() or "txt"
+				local file_type = string.lower(string.match(docfile, ".+%.([^.]+)") or "")
 				if file_type == "djvu" then
 					stored.highlight.to_fix = {"djvu invert y axle"}
 				end


### PR DESCRIPTION
1. Prior to introduction of the reader-chooser infrastructure we had a very useful feature of browsing (and therefore copying/moving/deleting/renaming/creating) filesystem tree accessing arbitrary files if the user privilege mode is set to any value higher than BEGINNER. This patch restores this functionality by checking the privilege levels in readerchooser and returning CREReader for any file type if there is no other reader associated with it (including files with no extension).
2. The code which determines file type in openFile() is actually unused, so it can be safely removed. Moreover, if the filename passed to openFile() happens to have no extension then this would crash openFile(). The reason this was not noticed before is because no such filename was passed to openFile() ever, but will be after this PR is merged.
3.  Don't crash in fileinfo on files with no extension --- treat a file with no extension as crengine-supported txt file.
