### PR TITLE
Re-sort Last Documents list on closing the document and remove unneeded page redraw

### DIFF
--- a/filehistory.lua
+++ b/filehistory.lua
@@ -239,6 +239,9 @@ function FileHistory:addAllCommands()
 			else
 				InfoMessage:inform("File does not exist ", DINFO_DELAY, 1, MSG_ERROR)
 			end
+			self:init()
+			self:setSearchResult(self.keywords)
+			self.pagedirty = true
 		end
 	)
 	self.commands:add(KEY_DEL, nil, "Del",

--- a/filehistory.lua
+++ b/filehistory.lua
@@ -230,18 +230,20 @@ function FileHistory:addAllCommands()
 			file_full_path = file_entry.dir .. "/" .. file_entry.name
 			if FileExists(file_full_path) then
 				openFile(file_full_path)
-				--reset height and item index if screen has been rotated
+				--[[
+				-- reset height and item index if screen has been rotated
+				-- not needed because we force portrait mode on document close
 				local item_no = self.perpage * (self.page - 1) + self.current
 				self.perpage = math.floor(G_height / self.spacing) - 2
 				self.current = item_no % self.perpage
 				self.page = math.floor(item_no / self.perpage) + 1
+				--]]
+				self:init()
+				self:setSearchResult(self.keywords)
 				self.pagedirty = true
 			else
 				InfoMessage:inform("File does not exist ", DINFO_DELAY, 1, MSG_ERROR)
 			end
-			self:init()
-			self:setSearchResult(self.keywords)
-			self.pagedirty = true
 		end
 	)
 	self.commands:add(KEY_DEL, nil, "Del",

--- a/unireader.lua
+++ b/unireader.lua
@@ -3238,7 +3238,7 @@ function UniReader:addAllCommands()
 		"enter highlight mode",
 		function(unireader)
 			unireader:startHighLightMode()
-			unireader:goto(unireader.pageno)
+			unireader:redrawCurrentPage()
 		end
 	)
 	self.commands:add(KEY_N, MOD_SHIFT, "N",

--- a/unireader.lua
+++ b/unireader.lua
@@ -3245,7 +3245,6 @@ function UniReader:addAllCommands()
 		"show all highlights",
 		function(unireader)
 			unireader:showHighLight()
-			unireader:goto(unireader.pageno)
 		end
 	)
 	self.commands:add(KEY_DOT, nil, ".",


### PR DESCRIPTION
This PR contains three unrelated (but minor enough to be combined) bugfixes:
1.  Remove unneeded redraw of the current page. The function `UniReader:showHighLight()` internally handles all cases where page redraw is necessary. Therefore, there is no need to redraw the current page (much less to :goto() to it, causing dummy pre-caching) on return from it.
2.  Re-sort the history list on closing a document. The "Last Documents" list is re-sorted on operations that modify it, such as deleting an entry. But opening/closing a document is also one such operation and, therefore, requires re-sorting. This bug was pointed out by user GriMel on the-ebook.org (Russian) forum.
3. On return from the highlight mode there is no need to call :goto() to the current page --- all that is needed is the redraw of the current page (which I have recently optimized to be more lightweight than a full :goto()).
