### PR TITLE
bugfix: write cache before new reflows && fix memory leak

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -535,6 +535,7 @@ static int reflowPage(lua_State *L) {
 		pthread_attr_init(&attr);
 		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 		pthread_create(&rf_thread, &attr, k2pdfopt_reflow_bmp, (void*) kctx);
+		pthread_attr_destroy(&attr);
 	} else {
 		k2pdfopt_reflow_bmp(kctx);
 	}

--- a/djvu.c
+++ b/djvu.c
@@ -531,7 +531,10 @@ static int reflowPage(lua_State *L) {
 	kctx->src = src;
 	if (kctx->precache) {
 		pthread_t rf_thread;
-		pthread_create(&rf_thread, NULL, k2pdfopt_reflow_bmp, (void*) kctx);
+		pthread_attr_t attr;
+		pthread_attr_init(&attr);
+		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+		pthread_create(&rf_thread, &attr, k2pdfopt_reflow_bmp, (void*) kctx);
 	} else {
 		k2pdfopt_reflow_bmp(kctx);
 	}

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -345,7 +345,7 @@ function KOPTReader:logReflowDuration(pageno, dur)
 	local file = io.open("reflowlog.txt", "a+")
 	if file then
 		if file:seek("end") == 0 then -- write the header only once
-			file:write(string.format("FILE\tPAGE\tDUR\n"))
+			file:write("FILE\tPAGE\tDUR\n")
 		end
 		file:write(string.format("%s\t%s\t%s\n", self.filename, pageno, dur))
 		file:close()
@@ -359,14 +359,15 @@ function KOPTReader:logMemoryUsage(pageno)
 	if status_file then
 		for line in status_file:lines() do
 			local s, n
-			s, n = line:gsub("VmData:%s-(%d+) kB", "%1")	
+			s, n = line:gsub("VmData:%s-(%d+) kB", "%1")
 			if n ~= 0 then data = tonumber(s) end
 			if data ~= -1 then break end
 		end
+		status_file:close()
 	end
 	if log_file then
 		if log_file:seek("end") == 0 then -- write the header only once
-			log_file:write(string.format("PAGE\tMEM\n"))
+			log_file:write("PAGE\tMEM\n")
 		end
 		log_file:write(string.format("%s\t%s\n", pageno, data))
 		log_file:close()

--- a/koptreader.lua
+++ b/koptreader.lua
@@ -352,7 +352,29 @@ function KOPTReader:logReflowDuration(pageno, dur)
 	end
 end
 
+function KOPTReader:logMemoryUsage(pageno)
+	local status_file = io.open("/proc/self/status", "r")
+	local log_file = io.open("reflow_mem_log.txt", "a+")
+	local data = -1
+	if status_file then
+		for line in status_file:lines() do
+			local s, n
+			s, n = line:gsub("VmData:%s-(%d+) kB", "%1")	
+			if n ~= 0 then data = tonumber(s) end
+			if data ~= -1 then break end
+		end
+	end
+	if log_file then
+		if log_file:seek("end") == 0 then -- write the header only once
+			log_file:write(string.format("PAGE\tMEM\n"))
+		end
+		log_file:write(string.format("%s\t%s\n", pageno, data))
+		log_file:close()
+	end
+end
+
 function KOPTReader:writeToCache(kc, page, pagehash, preCache)
+	--self:logMemoryUsage(self.pageno)
 	local tile = { x = 0, y = 0, w = G_width, h = G_height }
 	-- can we cache the full page?
 	local max_cache = self.cache_max_memsize

--- a/pdf.c
+++ b/pdf.c
@@ -615,7 +615,10 @@ static int reflowPage(lua_State *L) {
 	kctx->src = src;
 	if (kctx->precache) {
 		pthread_t rf_thread;
-		pthread_create( &rf_thread, NULL, k2pdfopt_reflow_bmp, (void*) kctx);
+		pthread_attr_t attr;
+		pthread_attr_init(&attr);
+		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+		pthread_create( &rf_thread, &attr, k2pdfopt_reflow_bmp, (void*) kctx);
 	} else {
 		k2pdfopt_reflow_bmp(kctx);
 	}

--- a/pdf.c
+++ b/pdf.c
@@ -619,6 +619,7 @@ static int reflowPage(lua_State *L) {
 		pthread_attr_init(&attr);
 		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 		pthread_create( &rf_thread, &attr, k2pdfopt_reflow_bmp, (void*) kctx);
+		pthread_attr_destroy(&attr);
 	} else {
 		k2pdfopt_reflow_bmp(kctx);
 	}


### PR DESCRIPTION
Reflowed bitmap should be written to cache before a new reflow is
started because all reflowing processes share the same masterinfo in
libk2pdfopt which contains the data of reflowed bitmap. If a new reflow
is started before a priviously reflowed bitmap is written, the
priviously reflowed bitmap will be corrupted which may cause
segmentation fault when it is written into cache finally.
