### PR TITLE
bugfix: waitForInput should return error when select returns zero

### DIFF
--- a/input.c
+++ b/input.c
@@ -274,7 +274,7 @@ static int waitForInput(lua_State *L) {
 	 * timeout at all.
 	 */
 	num = select(nfds, &fds, NULL, NULL, (usecs < 0) ? NULL : &timeout);
-	if(num < 0) {
+	if(num <= 0) {
 		return luaL_error(L, "Waiting for input failed: %d\n", errno);
 	}
 


### PR DESCRIPTION
On the RETURN VALUE section of `man select` it says:

```
       On success, select() and pselect() return the number of file descriptors contained
       in the three returned descriptor sets (that is, the total number of bits that  are
       set  in  readfds,  writefds,  exceptfds)  which may be zero if the timeout expires
       before anything interesting happens.  On error, -1 is returned, and errno  is  set
       appropriately; the sets and timeout become undefined, so do not rely on their con‐
       tents after an error.
```

So if select call returns zero error should be returned in waitForInput.
