### PR TITLE
Bugfix: crash when switching user privilege level

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -180,6 +180,8 @@ function FileChooser:setPath(newPath)
 
 		-- Dijkstra will hate me for this...
 		if newPath == oldPath then
+			self.page = 1
+			self.current = 1
 			return
 		end
 
@@ -653,10 +655,9 @@ Switching this mode on should allow developers & beta-testers to use some unstab
 and/or dangerous functions able to crash the reader. ]]
 
 function FileChooser:changeFileChooserMode()
-	local face_list = { "Safe mode for beginners", "Advanced mode for experienced users", "Expert mode for beta-testers & developers" }
 	local modes_menu = SelectMenu:new{
 		menu_title = "Set user privilege level",
-		item_array = face_list,
+		item_array = {"Safe mode for beginners", "Advanced mode for experienced users", "Expert mode for beta-testers & developers"},
 		current_entry = self.filemanager_expert_mode - 1,
 		}
 	local m = modes_menu:choose(0, G_height)


### PR DESCRIPTION
A simple sequence of steps can cause segmentation violation (coredump), namely:
1. Start KPV in a directory with just two page worths of books visible
   in "beginner" mode but containining more than two page worths of files
   visible in "expert" mode.
2. Change user privilege level from beginner to expert
3. Page down three times (to arrive on page 3)
4. Now change user privilege level back to beginner
5. Observe that the cursor is sitting on an empty line (non-existent book)
6. Try paging down -> segmentation violation. If you page up instead of down then everything will be OK and you won't be able to page down anymore.
