### PR TITLE
Crash when switching mode + other fixes

### DIFF
--- a/filechooser.lua
+++ b/filechooser.lua
@@ -36,7 +36,7 @@ FileChooser = {
 
 	-- modes that configures the filechoser for users with various purposes & skills
 	filemanager_mode, -- the value is set in reader.lua
-	-- symbolc definitions for filemanager_mode
+	-- symbolic definitions for filemanager_mode
 	RESTRICTED = 1, -- the filemanager content is restricted by files with reader-related extensions; safe renaming (no extension)
 	UNRESTRICTED = 2, -- no extension-based filtering; renaming with extensions; appreciable danger to crash crengine by improper docs
 }

--- a/fileinfo.lua
+++ b/fileinfo.lua
@@ -74,7 +74,8 @@ function FileInfo:getFolderContent()
 		if j == "file" then
 			files = files + 1
 			ftype = string.match(name, ".+%.([^.]+)")
-			if ftype and ReaderChooser:getReaderByType(string.lower(ftype)) then
+			if FileChooser.filemanager_mode == FileChooser.UNRESTRICTED or 
+				(ftype and ReaderChooser:getReaderByType(string.lower(ftype))) then
 				books = books + 1
 			end
 		elseif j == "directory" then

--- a/reader.lua
+++ b/reader.lua
@@ -135,7 +135,7 @@ if fontmap ~= nil then
 end
 
 -- set up the mode to manage files
-FileChooser.filemanager_expert_mode = G_reader_settings:readSetting("filemanager_expert_mode") or 1
+FileChooser.filemanager_mode = G_reader_settings:readSetting("filemanager_mode") or FileChooser.RESTRICTED
 InfoMessage:initInfoMessageSettings()
 local tmp = G_reader_settings:readSetting("G_battery_logging")
 if tmp ~= nil then

--- a/readerchooser.lua
+++ b/readerchooser.lua
@@ -72,7 +72,7 @@ function ReaderChooser:getReaderByType(ftype)
 	if #readers >= 1 then
 		return registry[readers[1]][1]
 	else
-		if FileChooser.filemanager_expert_mode  > FileChooser.BEGINNERS_MODE then
+		if FileChooser.filemanager_mode == FileChooser.UNRESTRICTED then
 			return CREReader
 		else
 			return nil
@@ -126,7 +126,7 @@ function ReaderChooser:getReaderByName(filename)
 	elseif #readers == 1 then
 		return registry[readers[1]][1]
 	else
-		if FileChooser.filemanager_expert_mode  > FileChooser.BEGINNERS_MODE then
+		if FileChooser.filemanager_mode == FileChooser.UNRESTRICTED then
 			return CREReader
 		else
 			return nil

--- a/unireader.lua
+++ b/unireader.lua
@@ -3437,14 +3437,6 @@ function UniReader:addAllCommands()
 			end
 		end
 	)
-	-- NuPogodi, 02.10.12: added functions to switch kpdfviewer mode from readers
-	self.commands:add(KEY_M, MOD_ALT, "M",
-		"set user privilege level",
-		function(unireader)
-			FileChooser:changeFileChooserMode()
-			self:redrawCurrentPage()
-		end
-	)
 	self.commands:add(KEY_E, nil, "E",
 		"configure event notifications",
 		function(unireader)


### PR DESCRIPTION
1. When switching file manager mode from restricted (formerly known as "Beginner") to unrestricted (formerly known as "Expert" or "Advanced") and paging down the file list KPV would crash.
2. Clean up the mess with the file manager mode --- we only need two modes: RESTRICTED and UNRESTRICTED. When we need more we'll add them. No need to pollute code with future "what if"s.
3. Setting file manager mode function has no place in unireader (it was formerly needed because the event notifications was dependent on it --- not anymore).
4. Bugfix: show the correct number of books in UNRESTRICTED file manager mode when pressing fiveway `Right` key on a directory.
