### PR TITLE
Don't use DroidSansFallbackFull.ttf fonts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ customupdate: all
 	$(STRIP) --strip-unneeded $(INSTALL_DIR)/libs/*
 	cp -rpL data/*.css $(INSTALL_DIR)/data
 	cp -rpL fonts $(INSTALL_DIR)
-	rm $(INSTALL_DIR)/fonts/droid/DroidSansFallback.ttf
+	rm $(INSTALL_DIR)/fonts/droid/DroidSansFallbackFull.ttf
 	cp -r git-rev resources $(INSTALL_DIR)
 	mkdir $(INSTALL_DIR)/fonts/host
 	zip -9 -r kindlepdfviewer-$(VERSION).zip $(INSTALL_DIR) launchpad/ kite/

--- a/font.lua
+++ b/font.lua
@@ -1,6 +1,6 @@
 Font = {
 	fontmap = {
-		cfont = "droid/DroidSansFallbackFull.ttf",		-- filemanager: for menu contents
+		cfont = "droid/DroidSansFallback.ttf",		-- filemanager: for menu contents
 		tfont = "droid/DroidSans.ttf",		-- filemanager: for title
 		ffont = "droid/DroidSans.ttf",		-- filemanager: for footer
 		infofont = "droid/DroidSans.ttf",	-- info messages


### PR DESCRIPTION
Use DroidSansFallback.ttf rather than DroidSansFallbackFull.ttf because that is what is used for rendering cjk glyphs by mupdf (see mupdf.patch).

This fixes the problem reported in PR #660
