### PR TITLE
Enable chapter marks in crengine header.

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -66,6 +66,7 @@ static int openDocument(lua_State *L) {
 	doc->text_view->setViewMode(view_mode, -1);
 	doc->text_view->Resize(width, height);
 	doc->text_view->LoadDocument(file_name);
+	doc->text_view->setPageHeaderInfo(PGHDR_AUTHOR|PGHDR_TITLE|PGHDR_PAGE_NUMBER|PGHDR_PAGE_COUNT|PGHDR_CHAPTER_MARKS|PGHDR_CLOCK);
 	doc->dom_doc = doc->text_view->getDocument();
 	doc->text_view->Render();
 


### PR DESCRIPTION
Since crengine can't get to the battery level I didn't enable the battery flag.

As for showing the Author/Title correctly (for Russian fb2 books), crengine tries the following fonts in this order:

```
DEFAULT_STATUS_FONT_NAME = "Arial Narrow, Arial, DejaVu Sans"
```

So, the solution is very simple: just copy the appropriate files (arialn*) to kindlepdfviewer/fonts directory and then the Author/Title in the header are displayed correctly.
