### PR TITLE
bugfix: Back when link shortcut keys are shown moves to the top of the page

### DIFF
--- a/unireader.lua
+++ b/unireader.lua
@@ -3436,7 +3436,11 @@ function UniReader:addAllCommands()
 				end
 
 				unireader:clearSelection()
-				unireader:gotoJump(goto_page, false, "link")
+				if goto_page ~= unireader.pageno then
+					unireader:gotoJump(goto_page, false, "link")
+				else
+					unireader:redrawCurrentPage()
+				end		
 
 			end
 		end


### PR DESCRIPTION
When you are in fit-to-content-fidth mode, and the screen is not at the top of the page, and you press L to see link shortcut keys, and then press back, you’ll be moved to the top of the page. This fixes it.
