### PR TITLE
Enable hyphenation and set status font

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -39,6 +39,7 @@ static int initCache(lua_State *L) {
 	int cache_size = luaL_optint(L, 1, (2 << 20) * 64); // 64Mb on disk cache for DOM
 
 	ldomDocCache::init(lString16("./cr3cache"), cache_size);
+	HyphMan::initDictionaries(lString16("data/hyph/"));
 
 	return 0;
 }
@@ -67,6 +68,7 @@ static int openDocument(lua_State *L) {
 	doc->text_view->Resize(width, height);
 	doc->text_view->LoadDocument(file_name);
 	doc->text_view->setPageHeaderInfo(PGHDR_AUTHOR|PGHDR_TITLE|PGHDR_PAGE_NUMBER|PGHDR_PAGE_COUNT|PGHDR_CHAPTER_MARKS|PGHDR_CLOCK);
+	doc->text_view->setStatusFontFace(lString8("Droid Sans"));
 	doc->dom_doc = doc->text_view->getDocument();
 	doc->text_view->Render();
 

--- a/crereader.lua
+++ b/crereader.lua
@@ -22,7 +22,7 @@ function CREReader:init()
 	self:addAllCommands()
 	self:adjustCreReaderCommands()
 
-	-- initialize cache
+	-- initialize cache and hyphenation engine
 	cre.initCache(1024*1024*64)
 	-- we need to initialize the CRE font list
 	local fonts = Font:getFontList()


### PR DESCRIPTION
Two changes:
1. Enable hyphenation engine. So, now our built-in crengine (with proper fonts and configuration settings) renders books as good as a standalone CoolReader (but some books take a bit longer to load).
2. Set the font used for status line to "Droid Sans" to render Russian Author/Title correctly. Although I personally prefer using "Arial Narrow" for this purpose, we cannot re-distribute it and therefore setting it to "Droid Sans" is a good compromise. Thanks to @kai771 for showing how to set the status font.
