### PR TITLE
bug fix in readerfont & minor code adjustment & page status in readerrolling

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -294,6 +294,33 @@ static int getFontFaces(lua_State *L) {
 	return 1;
 }
 
+static int setViewMode(lua_State *L) {
+	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+	LVDocViewMode view_mode = (LVDocViewMode)luaL_checkint(L, 2);
+
+	doc->text_view->setViewMode(view_mode, -1);
+
+	return 0;
+}
+
+static int setHeaderInfo(lua_State *L) {
+	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+	int info = luaL_checkint(L, 2);
+
+	doc->text_view->setPageHeaderInfo(info);
+
+	return 0;
+}
+
+static int setHeaderFont(lua_State *L) {
+	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+	const char *face = luaL_checkstring(L, 2);
+
+	doc->text_view->setStatusFontFace(lString8(face));
+
+	return 0;
+}
+
 static int setFontFace(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	const char *face = luaL_checkstring(L, 2);
@@ -632,6 +659,9 @@ static const struct luaL_Reg credocument_meth[] = {
 	{"getFontFace", getFontFace},
 	{"getToc", getTableOfContent},
 	/*--- set methods ---*/
+	{"setViewMode", setViewMode},
+	{"setHeaderInfo", setHeaderInfo},
+	{"setHeaderFont", setHeaderFont},
 	{"setFontFace", setFontFace},
 	{"setFontSize", setFontSize},
 	{"setDefaultInterlineSpace", setDefaultInterlineSpace},

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -1,6 +1,10 @@
 require "ui/geometry"
 
 CreDocument = Document:new{
+	-- this is defined in kpvcrlib/crengine/crengine/include/lvdocview.h
+	SCROLL_VIEW_MODE = 0,
+	PAGE_VIEW_MODE = 1,
+
 	_document = false,
 	engine_initilized = false,
 
@@ -70,9 +74,9 @@ function CreDocument:init()
 	local style_sheet = "./data/"..file_type..".css"
 
 	-- view_mode default to page mode
-	local view_mode = 1
+	local view_mode = self.PAGE_VIEW_MODE
 	if self.view_mode == "scroll" then
-		view_mode = 0
+		view_mode = self.SCROLL_VIEW_MODE
 	end
 	ok, self._document = pcall(cre.openDocument, self.file, style_sheet,
 				Screen:getWidth(), Screen:getHeight(), view_mode)

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -102,7 +102,7 @@ function CreDocument:getFontFace()
 end
 
 function CreDocument:setFontFace(new_font_face)
-	if new_font_face  then
+	if new_font_face then
 		self._document:setFontFace(new_font_face)
 	end
 end
@@ -112,7 +112,7 @@ function CreDocument:getFontSize()
 end
 
 function CreDocument:setFontSize(new_font_size)
-	if new_font_size  then
+	if new_font_size then
 		self._document:setFontSize(new_font_size)
 	end
 end

--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -10,7 +10,6 @@ CreDocument = Document:new{
 
 	line_space_percent = 100,
 	default_font = "Droid Sans Fallback",
-	view_mode = "page",
 }
 
 -- NuPogodi, 20.05.12: inspect the zipfile content
@@ -73,13 +72,10 @@ function CreDocument:init()
 	end
 	local style_sheet = "./data/"..file_type..".css"
 
-	-- view_mode default to page mode
-	local view_mode = self.PAGE_VIEW_MODE
-	if self.view_mode == "scroll" then
-		view_mode = self.SCROLL_VIEW_MODE
-	end
+	-- @TODO check the default view_mode to a global user configurable
+	-- variable  22.12 2012 (houqp)
 	ok, self._document = pcall(cre.openDocument, self.file, style_sheet,
-				Screen:getWidth(), Screen:getHeight(), view_mode)
+				Screen:getWidth(), Screen:getHeight(), self.PAGE_VIEW_MODE)
 	if not ok then
 		self.error_message = self.doc -- will contain error message
 		return
@@ -92,6 +88,22 @@ function CreDocument:init()
 	--self._document:setDefaultInterlineSpace(self.line_space_percent)
 end
 
+function CreDocument:drawCurrentView(target, x, y, rect, pos)
+	tile_bb = Blitbuffer.new(rect.w, rect.h)
+	self._document:drawCurrentPage(tile_bb)
+	target:blitFrom(tile_bb, x, y, 0, 0, rect.w, rect.h)
+end
+
+function CreDocument:drawCurrentViewByPos(target, x, y, rect, pos)
+	self._document:gotoPos(pos)
+	self:drawCurrentView(target, x, y, rect)
+end
+
+function CreDocument:drawCurrentViewByPage(target, x, y, rect, page)
+	self._document:gotoPage(page)
+	self:drawCurrentView(target, x, y, rect)
+end
+
 function CreDocument:hintPage(pageno, zoom, rotation)
 end
 
@@ -101,8 +113,40 @@ end
 function CreDocument:renderPage(pageno, rect, zoom, rotation)
 end
 
+function CreDocument:gotoXPointer(xpointer)
+	self._document:gotoXPointer(xpointer)
+end
+
+function CreDocument:getXPointer()
+	return self._document:getXPointer()
+end
+
+function CreDocument:getPosFromXPointer(xp)
+	return self._document:getPosFromXPointer(xp)
+end
+
+function CreDocument:getPageFromXPointer(xp)
+	return self._document:getPageFromXPointer(xp)
+end
+
 function CreDocument:getFontFace()
 	return self._document:getFontFace()
+end
+
+function CreDocument:getCurrentPos()
+	return self._document:getCurrentPos()
+end
+
+function Document:gotoPos(pos)
+	self._document:gotoPos(pos)
+end
+
+function CreDocument:gotoPage(page)
+	self._document:gotoPage(page)
+end
+
+function CreDocument:getCurrentPage()
+	return self._document:getCurrentPage()
 end
 
 function CreDocument:setFontFace(new_font_face)

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -234,13 +234,6 @@ function Document:drawPage(target, x, y, rect, pageno, zoom, rotation, render_mo
 		rect.w, rect.h)
 end
 
-function Document:drawCurrentView(target, x, y, rect, pos)
-	self._document:gotoPos(pos)
-	tile_bb = Blitbuffer.new(rect.w, rect.h)
-	self._document:drawCurrentPage(tile_bb)
-	target:blitFrom(tile_bb, x, y, 0, 0, rect.w, rect.h)
-end
-
 function Document:getPageText(pageno)
 	-- is this worth caching? not done yet.
 	local page = self._document:openPage(pageno)

--- a/frontend/ui/reader/readerfont.lua
+++ b/frontend/ui/reader/readerfont.lua
@@ -92,6 +92,9 @@ function ReaderFont:onShowFontMenu()
 	return true
 end
 
+--[[
+	UpdatePos event is used to tell ReaderRolling to update pos.
+--]]
 function ReaderFont:onChangeSize(direction)
 	local delta = 1
 	if direction == "decrease" then

--- a/frontend/ui/reader/readerfont.lua
+++ b/frontend/ui/reader/readerfont.lua
@@ -60,6 +60,11 @@ function ReaderFont:onReadSettings(config)
 		self.font_size = self.ui.document:getFontSize()
 	end
 	self.ui.document:setFontSize(self.font_size)
+	-- Dirty hack: we have to add folloing call in order to set
+	-- m_is_rendered(member of LVDocView) to true. Otherwise position inside
+	-- document will be reset to 0 on first view render.
+	-- So far, I don't know why this call will alter the value of m_is_rendered.
+	self.ui:handleEvent(Event:new("UpdatePos"))
 end
 
 function ReaderFont:onShowFontMenu()

--- a/frontend/ui/reader/readerview.lua
+++ b/frontend/ui/reader/readerview.lua
@@ -12,6 +12,8 @@ ReaderView = WidgetContainer:new{
 	outer_page_color = 7,
 	-- DjVu page rendering mode (used in djvu.c:drawPage())
 	render_mode = 0, -- default to COLOR
+	-- Crengine view mode
+	view_mode = "page", -- default to page mode
 
 	-- visible area within current viewing page
 	visible_area = Geom:new{x = 0, y = 0},
@@ -49,12 +51,21 @@ function ReaderView:paintTo(bb, x, y)
 			self.state.rotation,
 			self.render_mode)
 	else
-		self.ui.document:drawCurrentView(
-			bb,
-			x + inner_offset.x,
-			y + inner_offset.y,
-			self.visible_area,
-			self.state.pos)
+		if self.view_mode == "page" then
+			self.ui.document:drawCurrentViewByPage(
+				bb,
+				x + inner_offset.x,
+				y + inner_offset.y,
+				self.visible_area,
+				self.state.page)
+		else
+			self.ui.document:drawCurrentViewByPos(
+				bb,
+				x + inner_offset.x,
+				y + inner_offset.y,
+				self.visible_area,
+				self.state.pos)
+		end
 	end
 	-- dim last read area
 	if self.document.view_mode ~= "page" 


### PR DESCRIPTION
# reader font fix

After set font in ReaderFont:onReadSettings, we have to send UpdatePos
event in order to set m_is_rendered(member of LVDocView) to true.

Otherwise position inside document will be reset to 0 on first view
render, this makes the first page of document is always displayed on
document open.

So far, I don't know why this call will alter the value of m_is_rendered.
It just works...
# page status for readerrolling

now when rendering in page view mode, we only keep track of page
number instead of pos inside document. Because using pos inside
document for page view mode is really a bad idea and will lead to
many unsovlabe bugs...

XPointer is also added to credocument so we can do accurate jumping inside document.

view_mode status in removed from credocument because it should be kept track by UI widgets instead.
