### PR TITLE
bugfix: check renderpg hash before hinting page

### DIFF
--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -204,7 +204,11 @@ end
 -- a hint for the cache engine to paint a full page to the cache
 -- TODO: this should trigger a background operation
 function Document:hintPage(pageno, zoom, rotation)
-	self:renderPage(pageno, nil, zoom, rotation)
+	local hash_full_page = "renderpg|"..self.file.."|"..pageno.."|"..zoom.."|"..rotation
+	local tile = Cache:check(hash_full_page)
+	if not tile then
+		self:renderPage(pageno, nil, zoom, rotation)
+	end
 end
 
 --[[


### PR DESCRIPTION
This patch fixes the crash problem in pdf/djvu readers. Multiple same renderpg hashes could be used to indicate only one tile cache without this check, which will cause crash when the tile cache is freed multiple times.
