### PR TITLE
Bring back screen saver support

### DIFF
--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -31,7 +31,7 @@ typedef struct BlitBuffer {
 	uint8_t allocated;
 } BlitBuffer;
 
-int newBlitBufferNative(lua_State *L, int w, int h, BlitBuffer **newBuffer);
+int newBlitBufferNative(lua_State *L, int w, int h, int pitch, BlitBuffer **newBuffer);
 int luaopen_blitbuffer(lua_State *L);
 
 #endif

--- a/einkfb.c
+++ b/einkfb.c
@@ -282,7 +282,7 @@ static int getSize(lua_State *L) {
 static int getPitch(lua_State *L) {
 	FBInfo *fb = (FBInfo*) luaL_checkudata(L, 1, "einkfb");
 #ifndef EMULATE_READER
-	lua_pushinteger(L, fb->finfo.line_length);
+	lua_pushinteger(L, fb->finfo.line_length/2);
 #else
 	lua_pushinteger(L, fb->buf->pitch);
 #endif

--- a/einkfb.c
+++ b/einkfb.c
@@ -279,6 +279,16 @@ static int getSize(lua_State *L) {
 	return 2;
 }
 
+static int getPitch(lua_State *L) {
+	FBInfo *fb = (FBInfo*) luaL_checkudata(L, 1, "einkfb");
+#ifndef EMULATE_READER
+	lua_pushinteger(L, fb->finfo.line_length);
+#else
+	lua_pushinteger(L, fb->buf->pitch);
+#endif
+	return 1;
+}
+
 static int closeFrameBuffer(lua_State *L) {
 	FBInfo *fb = (FBInfo*) luaL_checkudata(L, 1, "einkfb");
 	// should be save if called twice
@@ -432,6 +442,7 @@ static const struct luaL_Reg einkfb_meth[] = {
 	{"getOrientation", einkGetOrientation},
 	{"setOrientation", einkSetOrientation},
 	{"getSize", getSize},
+	{"getPitch", getPitch},
 	{NULL, NULL}
 };
 

--- a/frontend/ui/device.lua
+++ b/frontend/ui/device.lua
@@ -83,16 +83,16 @@ function Device:intoScreenSaver()
 	--os.execute("echo 'screensaver in' >> /mnt/us/event_test.txt")
 	if self.charging_mode == false and self.screen_saver_mode == false then
 		Screen:saveCurrentBB()
-		msg = InfoMessage:new{"Going into screensaver... "}
-		UIManager:show(msg)
+		--msg = InfoMessage:new{"Going into screensaver... "}
+		--UIManager:show(msg)
 
 		Screen.kpv_rotation_mode = Screen.cur_rotation_mode
 		Screen.fb:setOrientation(Screen.native_rotation_mode)
-		util.sleep(1)
-		os.execute("killall -cont cvm")
+		--util.sleep(1)
+		--os.execute("killall -cont cvm")
 		self.screen_saver_mode = true
 
-		UIManager:close(msg)
+		--UIManager:close(msg)
 	end
 end
 
@@ -100,7 +100,7 @@ function Device:outofScreenSaver()
 	--os.execute("echo 'screensaver out' >> /mnt/us/event_test.txt")
 	if self.screen_saver_mode == true and self.charging_mode == false then
 		util.usleep(1500000)
-		os.execute("killall -stop cvm")
+		--os.execute("killall -stop cvm")
 		Screen.fb:setOrientation(Screen.kpv_rotation_mode)
 		Screen:restoreFromSavedBB()
 		Screen.fb:refresh(0)

--- a/frontend/ui/inputevent.lua
+++ b/frontend/ui/inputevent.lua
@@ -390,18 +390,9 @@ function Input:waitEvent(timeout_us, timeout_s)
 				keycode = self.rotation_map[self.rotation][keycode]
 			end
 
-			if keycode == "IntoSS" then
-				Device:intoScreenSaver()
-				return
-			elseif keycode == "OutOfSS" then
-				Device:outofScreenSaver()
-				return
-			elseif keycode == "Charging" then
-				Device:usbPlugIn()
-				return
-			elseif keycode == "NotCharging" then
-				Device:usbPlugOut()
-				return
+			if keycode == "IntoSS" or keycode == "OutOfSS"
+			or keycode == "Charging" or keycode == "NotCharging" then
+				return keycode
 			end
 
 			-- handle modifier keys

--- a/frontend/ui/reader/readermenu.lua
+++ b/frontend/ui/reader/readermenu.lua
@@ -34,7 +34,7 @@ function ReaderMenu:setUpdateItemTable()
 			{
 				text = "rotate 90 degree clockwise",
 				callback = function()
-					Screen:screenRotate("clockwise")
+					--Screen:screenRotate("clockwise")
 					self.ui:handleEvent(
 						Event:new("SetDimensions", Screen:getSize()))
 				end
@@ -42,7 +42,7 @@ function ReaderMenu:setUpdateItemTable()
 			{
 				text = "rotate 90 degree anticlockwise",
 				callback = function()
-					Screen:screenRotate("anticlockwise")
+					--Screen:screenRotate("anticlockwise")
 					self.ui:handleEvent(
 						Event:new("SetDimensions", Screen:getSize()))
 				end

--- a/frontend/ui/screen.lua
+++ b/frontend/ui/screen.lua
@@ -84,6 +84,10 @@ function Screen:getHeight()
 	return h
 end
 
+function Screen:getPitch()
+	return self.fb:getPitch()
+end
+
 function Screen:updateRotationMode()
 	-- in EMU mode, you will always get 0 from getOrientation()
 	self.cur_rotation_mode = self.fb:getOrientation()

--- a/frontend/ui/screen.lua
+++ b/frontend/ui/screen.lua
@@ -101,11 +101,11 @@ function Screen:saveCurrentBB()
 	local width, height = self:getWidth(), self:getHeight()
 
 	if not self.saved_bb then
-		self.saved_bb = Blitbuffer.new(width, height)
+		self.saved_bb = Blitbuffer.new(width, height, self:getPitch())
 	end
 	if self.saved_bb:getWidth() ~= width then
 		self.saved_bb:free()
-		self.saved_bb = Blitbuffer.new(width, height)
+		self.saved_bb = Blitbuffer.new(width, height, self:getPitch())
 	end
 	self.saved_bb:blitFullFrom(self.fb.bb)
 end

--- a/frontend/ui/ui.lua
+++ b/frontend/ui/ui.lua
@@ -205,7 +205,17 @@ function UIManager:run()
 		-- delegate input_event to handler
 		if input_event then
 			DEBUG(input_event)
-			self:sendEvent(input_event)
+			if input_event == "IntoSS" then
+				Device:intoScreenSaver()
+			elseif input_event == "OutOfSS" then
+				Device:outofScreenSaver()
+			elseif input_event == "Charging" then
+				Device:usbPlugIn()
+			elseif input_event == "NotCharging" then
+				Device:usbPlugOut()
+			else
+				self:sendEvent(input_event)
+			end
 		end
 	end
 end

--- a/ft.c
+++ b/ft.c
@@ -78,7 +78,7 @@ static int renderGlyph(lua_State *L) {
 	lua_newtable(L);
 
 	BlitBuffer *bb;
-	int result = newBlitBufferNative(L, w, h, &bb);
+	int result = newBlitBufferNative(L, w, h, 0, &bb);
 	if(result != 1) {
 		return result;
 	}

--- a/kpdf.sh
+++ b/kpdf.sh
@@ -21,7 +21,7 @@ if test "$1" == "--framework_stop"; then
 fi
 
 # stop cvm
-killall -stop cvm
+#killall -stop cvm
 
 # finally call reader
 ./reader.lua "$1" 2> crash.log

--- a/mupdfimg.c
+++ b/mupdfimg.c
@@ -93,7 +93,7 @@ static int toBlitBuffer(lua_State *L) {
 		}
 	}
 
-	ret = newBlitBufferNative(L, img->pixmap->w, img->pixmap->h, &bb);
+	ret = newBlitBufferNative(L, img->pixmap->w, img->pixmap->h, 0, &bb);
 	if(ret != 1) {
 		// TODO (?): fail more gracefully, clean up mem?
 		return ret;


### PR DESCRIPTION
Seems that 5.3 firmware is different from v3 firmware on lipc-wait-event. In v5 firmware, when cvm is stopped, lipc-wait-event won't be able to catch any events. So we have to leave it running...

Currently, switching between screen savers works fine as long as we don't rotate the screen. I will rewrite screen rotation code to make cvm happy later.
