### PR TITLE
two bug fixes

### DIFF
--- a/crereader.lua
+++ b/crereader.lua
@@ -160,12 +160,14 @@ end
 
 function CREReader:getLastPageOrPos()
 	local last_percent = self.settings:readSetting("last_percent")
+	local last_xp = self.settings:readSetting("last_xpointer")
+
+	if last_xp then
+		return last_xp
+	end
+	-- read last_percent for backward compatibility
 	if last_percent then
-		if self.view_mode == "scroll" then
-			return math.floor((last_percent * self.doc:getFullHeight()) / 10000)
-		else
-			return math.floor((last_percent * self.doc:getPages()) / 10000)
-		end
+		return math.floor((last_percent * self.doc:getPages()) / 10000)
 	else
 		return (self.view_mode == "scroll" and 0) or 1
 	end
@@ -180,7 +182,9 @@ function CREReader:saveSpecialSettings()
 end
 
 function CREReader:saveLastPageOrPos()
-	self.settings:saveSetting("last_percent", self.percent)
+	-- last_percent is deprecated
+	self.settings:saveSetting("last_percent", nil)
+	self.settings:saveSetting("last_xpointer", self.doc:getXPointer())
 end
 
 ----------------------------------------------------

--- a/crereader.lua
+++ b/crereader.lua
@@ -183,7 +183,7 @@ end
 
 function CREReader:saveLastPageOrPos()
 	-- last_percent is deprecated
-	self.settings:saveSetting("last_percent", nil)
+	self.settings:saveSetting("last_percent", self.percent)
 	self.settings:saveSetting("last_xpointer", self.doc:getXPointer())
 end
 

--- a/crereader.lua
+++ b/crereader.lua
@@ -573,6 +573,7 @@ function CREReader:adjustCreReaderCommands()
 		"rotate screen counterclockwise",
 		function(self)
 			self:screenRotate("anticlockwise")
+			self.toc = nil
 		end
 	)
 	-- CW-rotation
@@ -580,6 +581,7 @@ function CREReader:adjustCreReaderCommands()
 		"rotate screen clockwise",
 		function(self)
 			self:screenRotate("clockwise")
+			self.toc = nil
 		end
 	)
 	-- navigate between chapters by Shift+Up & Shift-Down
@@ -641,6 +643,7 @@ function CREReader:adjustCreReaderCommands()
 			Debug("font zoomed to", self.font_zoom)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:zoomFont(delta)
+			self.toc = nil
 			self:goto(prev_xpointer, nil, "xpointer")
 		end
 	)
@@ -660,6 +663,7 @@ function CREReader:adjustCreReaderCommands()
 			Debug("line spacing set to", self.line_space_percent)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:setDefaultInterlineSpace(self.line_space_percent)
+			self.toc = nil
 			self:goto(prev_xpointer, nil, "xpointer")
 		end
 	)
@@ -722,6 +726,7 @@ function CREReader:adjustCreReaderCommands()
 				self.doc:setFontFace(face_list[item_no])
 				self.font_face = face_list[item_no]
 			end
+			self.toc = nil
 			self:goto(prev_xpointer, nil, "xpointer")
 		end
 	)
@@ -748,6 +753,7 @@ function CREReader:adjustCreReaderCommands()
 				G_reader_settings:saveSetting("header_font", self.header_font)
 				self.doc:setHeaderFont(self.header_font)
 			end
+			self.toc = nil
 			self:goto(prev_xpointer, nil, "xpointer")
 		end
 	)
@@ -765,6 +771,7 @@ function CREReader:adjustCreReaderCommands()
 			InfoMessage:inform("Changing font-weight...", DINFO_NODELAY, 1, MSG_AUX)
 			local prev_xpointer = self.doc:getXPointer()
 			self.doc:toggleFontBolder()
+			self.toc = nil
 			self:goto(prev_xpointer, nil, "xpointer")
 		end
 	)
@@ -866,6 +873,7 @@ function CREReader:adjustCreReaderCommands()
 			self.settings:saveSetting("view_mode", self.view_mode)
 			InfoMessage:inform("Changing to "..self.view_mode.." mode...", DINFO_DELAY, 1, MSG_AUX)
 			self.doc:setViewMode(view_mode_code)
+			self.toc = nil
 			self:redrawCurrentPage()
 		end
 	)

--- a/reader.lua
+++ b/reader.lua
@@ -38,7 +38,11 @@ function openFile(filename)
 		if ok then
 			reader:loadSettings(filename)
 			page_num = reader:getLastPageOrPos()
-			reader:goto(tonumber(page_num), true)
+			if type(page_num) == "string" then
+				reader:goto(page_num, true, "xpointer")
+			else
+				reader:goto(page_num, true)
+			end
 			G_reader_settings:saveSetting("lastfile", filename)
 			return reader:inputLoop()
 		else

--- a/unireader.lua
+++ b/unireader.lua
@@ -2517,9 +2517,6 @@ function UniReader:inputLoop()
 	self.show_overlap = 0
 	Screen:setRotationMode(0)
 	self:setDefaults()
-	if self.doc ~= nil then
-		self.doc:close()
-	end
 	if self.globalzoom_mode == self.ZOOM_FIT_TO_CONTENT_WIDTH_PAN then
 		self.globalzoom_mode = self.ZOOM_FIT_TO_CONTENT_WIDTH
 	elseif self.pan_by_page then
@@ -2546,6 +2543,10 @@ function UniReader:inputLoop()
 		self.settings:close()
 	end
 	self.bbox.enabled = false
+
+	if self.doc ~= nil then
+		self.doc:close()
+	end
 
 	return keep_running
 end


### PR DESCRIPTION
- use last_xpointer to keep reading progress for crereader

adapted from commit https://github.com/houqp/kindlepdfviewer/commit/e7e6a2be9c3258c452a8329db3c2d56638e99480

This fix a bug in crereader, i.e. when in page mode, keep reopening a document gives you different pages each time.
- reset self.toc on document reformat as discussed in #692 
