### PR TITLE
bugfix: calculate current config value or arg at runtime

### DIFF
--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -191,12 +191,13 @@ KoptInterface = {}
 -- get reflow context
 function KoptInterface:getKOPTContext(doc, pageno, bbox)
 	local kc = KOPTContext.new()
+	local screen_size = Screen:getSize()
 	kc:setTrim(doc.configurable.trim_page)
 	kc:setWrap(doc.configurable.text_wrap)
 	kc:setIndent(doc.configurable.detect_indent)
 	kc:setRotate(doc.configurable.screen_rotation)
 	kc:setColumns(doc.configurable.max_columns)
-	kc:setDeviceDim(doc.screen_size.w, doc.screen_size.h)
+	kc:setDeviceDim(screen_size.w, screen_size.h)
 	kc:setDeviceDPI(doc.screen_dpi)
 	kc:setStraighten(doc.configurable.auto_straighten)
 	kc:setJustification(doc.configurable.justification)
@@ -215,8 +216,9 @@ end
 function KoptInterface:getPageDimensions(doc, pageno, zoom, rotation)
 	-- check cached page size
 	self.cur_bbox = doc:getPageBBox(pageno)
-	local bbox = self.cur_bbox
-	local hash = "kctx|"..doc.file.."|"..pageno.."|"..doc.configurable:hash("|").."|"..bbox.x0.."|"..bbox.y0.."|"..bbox.x1.."|"..bbox.y1
+	self.screen_mode = Screen:getScreenMode()
+	local bbox_hash = self.cur_bbox.x0.."|"..self.cur_bbox.y0.."|"..self.cur_bbox.x1.."|"..self.cur_bbox.y1
+	local hash = "kctx|"..doc.file.."|"..pageno.."|"..doc.configurable:hash("|").."|"..bbox_hash.."|"..self.screen_mode
 	local cached = Cache:check(hash)
 	if not cached then
 		local kc = self:getKOPTContext(doc, pageno, self.cur_bbox)
@@ -240,8 +242,9 @@ end
 function KoptInterface:renderPage(doc, pageno, rect, zoom, rotation, render_mode)
 	doc.render_mode = render_mode
 	self.cur_bbox = doc:getPageBBox(pageno)
-	local bbox = self.cur_bbox
-	local hash = "renderpg|"..doc.file.."|"..pageno.."|"..doc.configurable:hash("|").."|"..bbox.x0.."|"..bbox.y0.."|"..bbox.x1.."|"..bbox.y1
+	self.screen_mode = Screen:getScreenMode()
+	local bbox_hash = self.cur_bbox.x0.."|"..self.cur_bbox.y0.."|"..self.cur_bbox.x1.."|"..self.cur_bbox.y1
+	local hash = "renderpg|"..doc.file.."|"..pageno.."|"..doc.configurable:hash("|").."|"..bbox_hash.."|"..self.screen_mode
 	local page_size = self:getPageDimensions(doc, pageno, zoom, rotation)
 	-- this will be the size we actually render
 	local size = page_size
@@ -272,13 +275,13 @@ function KoptInterface:renderPage(doc, pageno, rect, zoom, rotation, render_mode
 	}
 
 	-- draw to blitbuffer
-	local kc_hash = "kctx|"..doc.file.."|"..pageno.."|"..doc.configurable:hash("|").."|"..bbox.x0.."|"..bbox.y0.."|"..bbox.x1.."|"..bbox.y1
+	local kc_hash = "kctx|"..doc.file.."|"..pageno.."|"..doc.configurable:hash("|").."|"..bbox_hash.."|"..self.screen_mode
 	local page = doc._document:openPage(pageno)
 	local cached = Cache:check(kc_hash)
 	if cached then
 		page:rfdraw(cached.kctx, tile.bb)
 		page:close()
-		DEBUG("cached hash", hash)
+		--DEBUG("cached hash", hash)
 		if not Cache:check(hash) then
 			Cache:insert(hash, tile)
 		end
@@ -289,7 +292,7 @@ end
 
 function KoptInterface:drawPage(doc, target, x, y, rect, pageno, zoom, rotation, render_mode)
 	local tile = self:renderPage(doc, pageno, rect, zoom, rotation, render_mode)
-	DEBUG("now painting", tile, rect)
+	--DEBUG("now painting", tile, rect)
 	target:blitFrom(tile.bb,
 		x, y, 
 		rect.x - tile.excerpt.x,

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -28,6 +28,7 @@ KoptOptions = {
 				toggle = {"portrait", "landscape"},
 				args = {"portrait", "landscape"},
 				default_arg = Screen:getScreenMode(),
+				current_func = function() return Screen:getScreenMode() end,
 				event = "SetScreenMode",
 			}
 		}

--- a/frontend/ui/config.lua
+++ b/frontend/ui/config.lua
@@ -380,7 +380,9 @@ function ConfigOption:init()
 			local current_item = nil
 			if self.options[c].name then
 				if self.options[c].values then
-					local val = self.config.configurable[self.options[c].name]
+					-- check if current value is stored in configurable or calculated in runtime
+					local val = self.options[c].current_func and self.options[c].current_func()
+								or self.config.configurable[self.options[c].name]
 					local min_diff = math.abs(val - self.options[c].values[1])
 					local diff = nil
 					for index, val_ in pairs(self.options[c].values) do
@@ -395,7 +397,9 @@ function ConfigOption:init()
 						end
 					end
 				elseif self.options[c].args then
-					local arg = self.config.configurable[self.options[c].name]
+					-- check if current arg is stored in configurable or calculated in runtime
+					local arg = self.options[c].current_func and self.options[c].current_func()
+								or self.config.configurable[self.options[c].name]
 					for idx, arg_ in pairs(self.options[c].args) do
 						if arg_ == arg then
 							current_item = idx

--- a/frontend/ui/reader/readermenu.lua
+++ b/frontend/ui/reader/readermenu.lua
@@ -58,6 +58,8 @@ function ReaderMenu:setUpdateItemTable()
 	table.insert(self.item_table, {
 		text = "Return to file manager",
 		callback = function()
+			self.ui:handleEvent(Event:new("RestoreScreenMode", 
+				G_reader_settings:readSetting("screen_mode") or "portrait"))
 			UIManager:close(self.menu_container)
 			self.ui:onClose()
 		end

--- a/frontend/ui/reader/readerview.lua
+++ b/frontend/ui/reader/readerview.lua
@@ -132,7 +132,16 @@ end
 
 function ReaderView:onSetScreenMode(new_mode)
 	if new_mode == "landscape" or new_mode == "portrait" then
+		self.screen_mode = new_mode
 		Screen:setScreenMode(new_mode)
+		self.ui:handleEvent(Event:new("SetDimensions", Screen:getSize()))
+	end
+	return true
+end
+
+function ReaderView:onRestoreScreenMode(old_mode)
+	if old_mode == "landscape" or old_mode == "portrait" then
+		Screen:setScreenMode(old_mode)
 		self.ui:handleEvent(Event:new("SetDimensions", Screen:getSize()))
 	end
 	return true
@@ -146,15 +155,24 @@ end
 
 function ReaderView:onReadSettings(config)
 	self.render_mode = config:readSetting("render_mode") or 0
+	self.init_screen_mode = config:readSetting("screen_mode") or "portrait"
 end
 
 function ReaderView:onPageUpdate(new_page_no)
 	self.state.page = new_page_no
+	if self.init_screen_mode then
+		self.ui:handleEvent(Event:new("SetScreenMode", self.init_screen_mode))
+		self.init_screen_mode = nil
+	end
 	self:recalculate()
 end
 
 function ReaderView:onPosUpdate(new_pos)
 	self.state.pos = new_pos
+	if self.init_screen_mode then
+		self.ui:handleEvent(Event:new("SetScreenMode", self.init_screen_mode))
+		self.init_screen_mode = nil
+	end
 	self:recalculate()
 end
 
@@ -192,4 +210,5 @@ end
 
 function ReaderView:onCloseDocument()
 	self.ui.doc_settings:saveSetting("render_mode", self.render_mode)
+	self.ui.doc_settings:saveSetting("screen_mode", self.screen_mode)
 end

--- a/frontend/ui/reader/readerview.lua
+++ b/frontend/ui/reader/readerview.lua
@@ -155,24 +155,20 @@ end
 
 function ReaderView:onReadSettings(config)
 	self.render_mode = config:readSetting("render_mode") or 0
-	self.init_screen_mode = config:readSetting("screen_mode") or "portrait"
+	local screen_mode = config:readSetting("screen_mode")
+	if screen_mode then
+	    table.insert(self.ui.postInitCallback, function()
+	        self:onSetScreenMode(screen_mode) end)
+	end
 end
 
 function ReaderView:onPageUpdate(new_page_no)
 	self.state.page = new_page_no
-	if self.init_screen_mode then
-		self.ui:handleEvent(Event:new("SetScreenMode", self.init_screen_mode))
-		self.init_screen_mode = nil
-	end
 	self:recalculate()
 end
 
 function ReaderView:onPosUpdate(new_pos)
 	self.state.pos = new_pos
-	if self.init_screen_mode then
-		self.ui:handleEvent(Event:new("SetScreenMode", self.init_screen_mode))
-		self.init_screen_mode = nil
-	end
 	self:recalculate()
 end
 


### PR DESCRIPTION
This patch fixed the screen rotation bug that once going into landscape mode from document menu the config menu cannot rotate screen any more.
