### PR TITLE
fix visible_area recalculate for manual crop in reflow mode

### DIFF
--- a/frontend/ui/reader/readercropping.lua
+++ b/frontend/ui/reader/readercropping.lua
@@ -5,14 +5,17 @@ ReaderCropping = InputContainer:new{}
 function ReaderCropping:onPageCrop(mode)
 	if mode == "auto" then return end
 	local orig_reflow_mode = self.document.configurable.text_wrap
-	self.document.configurable.text_wrap = 0
 	self.ui:handleEvent(Event:new("CloseConfig"))
 	self.cropping_zoommode = true
 	self.cropping_offset = true
-	-- we are already in page mode, tell ReaderView to recalculate stuff
-	-- for non-reflow mode
-	self.view:recalculate()
-	self.cropping_zoommode = false
+	if self.document.configurable.text_wrap == 1 then
+		self.document.configurable.text_wrap = 0
+		-- if we are in reflow mode, then we are already in page
+		-- mode, just force readerview to recalculate visible_area
+		self.view:recalculate()
+	else
+		self.ui:handleEvent(Event:new("SetZoomMode", "page"))
+	end
 	local ubbox = self.document:getPageBBox(self.current_page)
 	--DEBUG("used page bbox", ubbox)
 	self.crop_bbox = BBoxWidget:new{

--- a/frontend/ui/reader/readercropping.lua
+++ b/frontend/ui/reader/readercropping.lua
@@ -9,7 +9,9 @@ function ReaderCropping:onPageCrop(mode)
 	self.ui:handleEvent(Event:new("CloseConfig"))
 	self.cropping_zoommode = true
 	self.cropping_offset = true
-	self.ui:handleEvent(Event:new("SetZoomMode", "page"))
+	-- we are already in page mode, tell ReaderView to recalculate stuff
+	-- for non-reflow mode
+	self.view:recalculate()
 	self.cropping_zoommode = false
 	local ubbox = self.document:getPageBBox(self.current_page)
 	--DEBUG("used page bbox", ubbox)


### PR DESCRIPTION
Calling `self.ui:handleEvent(Event:new("SetZoomMode", "page"))` will have no effect because the original page mode is always page mode in reflow mode. In that case, we need to call ReaderView:recalculate to  force update visible_area.
