### PR TITLE
separate abstract interface EventListener from Widget

### DIFF
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -2,8 +2,6 @@ require "ui/geometry"
 
 CreOptions = {
 	prefix = 'copt',
-	default_options = {
-	},
 	{
 		icon = "resources/icons/appbar.transform.rotate.right.large.png",
 		options = {

--- a/frontend/document/djvudocument.lua
+++ b/frontend/document/djvudocument.lua
@@ -72,19 +72,19 @@ function DjvuDocument:getPageDimensions(pageno, zoom, rotation)
 	end
 end
 
-function DjvuDocument:renderPage(pageno, rect, zoom, rotation, render_mode)
+function DjvuDocument:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
 	if self.configurable.text_wrap == 1 then
 		return self.koptinterface:renderPage(self, pageno, rect, zoom, rotation, render_mode)
 	else
-		return Document.renderPage(self, pageno, rect, zoom, rotation, render_mode)
+		return Document.renderPage(self, pageno, rect, zoom, rotation, gamma, render_mode)
 	end
 end
 
-function DjvuDocument:drawPage(target, x, y, rect, pageno, zoom, rotation, render_mode)
+function DjvuDocument:drawPage(target, x, y, rect, pageno, zoom, rotation, gamma, render_mode)
 	if self.configurable.text_wrap == 1 then
 		self.koptinterface:drawPage(self, target, x, y, rect, pageno, zoom, rotation, render_mode)
 	else
-		Document.drawPage(self, target, x, y, rect, pageno, zoom, rotation, render_mode)
+		Document.drawPage(self, target, x, y, rect, pageno, zoom, rotation, gamma, render_mode)
 	end
 end
 

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -124,7 +124,6 @@ KoptOptions = {
 					},
 					{
 						event = "RestoreZoomMode",
-						args = {"page", nil},
 					},
 				}
 			},

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -104,6 +104,8 @@ KoptOptions = {
 				item_align_center = 0.8,
 				values = {2.0, 1.5, 1.0, 0.5, 0.2},
 				default_value = 1.0,
+				event = "GammaUpdate",
+				args = {0.5, 0.8, 1.0, 2.0, 4.0},
 			}
 		}
 	},

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -6,19 +6,6 @@ require "ui/reader/readerconfig"
 
 KoptOptions = {
 	prefix = 'kopt',
-	default_options = {
-		{
-			widget = "ProgressWidget",
-			widget_align_center = 0.8,
-			width = Screen:getWidth()*0.7,
-			height = 5,
-			percentage = 0.0,
-			item_text = {"Goto"},
-			item_align_center = 0.2,
-			item_font_face = "tfont",
-			item_font_size = 20,
-		}
-	},
 	{
 		icon = "resources/icons/appbar.transform.rotate.right.large.png",
 		options = {

--- a/frontend/document/pdfdocument.lua
+++ b/frontend/document/pdfdocument.lua
@@ -68,19 +68,19 @@ function PdfDocument:getPageDimensions(pageno, zoom, rotation)
 	end
 end
 
-function PdfDocument:renderPage(pageno, rect, zoom, rotation, render_mode)
+function PdfDocument:renderPage(pageno, rect, zoom, rotation, gamma, render_mode)
 	if self.configurable.text_wrap == 1 then
 		return self.koptinterface:renderPage(self, pageno, rect, zoom, rotation, render_mode)
 	else
-		return Document.renderPage(self, pageno, rect, zoom, rotation, render_mode)
+		return Document.renderPage(self, pageno, rect, zoom, rotation, gamma, render_mode)
 	end
 end
 
-function PdfDocument:drawPage(target, x, y, rect, pageno, zoom, rotation, render_mode)
+function PdfDocument:drawPage(target, x, y, rect, pageno, zoom, rotation, gamma, render_mode)
 	if self.configurable.text_wrap == 1 then
 		self.koptinterface:drawPage(self, target, x, y, rect, pageno, zoom, rotation, render_mode)
 	else
-		Document.drawPage(self, target, x, y, rect, pageno, zoom, rotation, render_mode)
+		Document.drawPage(self, target, x, y, rect, pageno, zoom, rotation, gamma, render_mode)
 	end
 end
 

--- a/frontend/math.lua
+++ b/frontend/math.lua
@@ -22,4 +22,39 @@ function math.oddEven(number)
 	end
 end
 
+function tmin_max(tab, func, op)
+	if #tab == 0 then return nil, nil end
+	local index, value = 1, tab[1]
+    for i = 2, #tab do
+    	if func then
+    		if func(value, tab[i]) then
+	        	index, value = i, tab[i]
+	        end
+	    elseif op == "min" then
+	    	if value > tab[i] then
+	    		index, value = i, tab[i]
+	    	end
+	    elseif op == "max" then
+	   		if value < tab[i] then
+	    		index, value = i, tab[i]
+	    	end
+	    end
+    end
+    return index, value
+end
 
+--[[
+Return the minimum element of a table.
+The optional argument func specifies a one-argument ordering function.
+]]--
+function math.tmin(tab, func)
+	return tmin_max(tab, func, "min")
+end
+
+--[[
+Return the maximum element of a table.
+The optional argument func specifies a one-argument ordering function.
+]]--
+function math.tmax(tab, func)
+	return tmin_max(tab, func, "max")
+end

--- a/frontend/ui/bbox.lua
+++ b/frontend/ui/bbox.lua
@@ -26,28 +26,12 @@ function BBoxWidget:init()
 					range = self.view.dimen,
 				}
 			},
-			Confirm = {
-				GestureRange:new{
-					ges = "double_tap",
-					range = self.view.dimen,
-				}
-			},
-			Cancel = {
-				GestureRange:new{
-					ges = "hold",
-					range = self.view.dimen,
-				}
-			},
 		}
 	end
 end
 
 function BBoxWidget:getSize()
-	return Geom:new{
-		x = 0, y = 0,
-		w = Screen:getWidth(),
-		h = Screen:getHeight()
-	}
+	return self.view.dimen
 end
 
 function BBoxWidget:paintTo(bb, x, y)
@@ -168,17 +152,5 @@ end
 function BBoxWidget:onPanAdjust(arg, ges)
 	-- up to 3 updates per second
 	self:adjustScreenBBox(ges, 3.0)
-	return true
-end
-
-function BBoxWidget:onConfirm()
-	local new_bbox = self:getModifiedPageBBox()
-	self.ui:handleEvent(Event:new("ConfirmPageCrop", new_bbox))
-	return true
-end
-
-function BBoxWidget:onCancel()
-	UIManager:close(self.crop_bbox)
-	self.ui:handleEvent(Event:new("CancelPageCrop"))
 	return true
 end

--- a/frontend/ui/bbox.lua
+++ b/frontend/ui/bbox.lua
@@ -110,22 +110,39 @@ function BBoxWidget:onAdjustScreenBBox(ges, rate)
 	local upper_right = Geom:new{ x = bbox.x1, y = bbox.y0}
 	local bottom_left = Geom:new{ x = bbox.x0, y = bbox.y1}
 	local bottom_right = Geom:new{ x = bbox.x1, y = bbox.y1}
-	local corners = {upper_left, upper_right, bottom_left, bottom_right}
-	table.sort(corners, function(a,b)
-		return a:distance(ges.pos) < b:distance(ges.pos)
+	local upper_center = Geom:new{ x = (bbox.x0 + bbox.x1) / 2, y = bbox.y0}
+	local bottom_center = Geom:new{ x = (bbox.x0 + bbox.x1) / 2, y = bbox.y1}
+	local right_center = Geom:new{ x = bbox.x1, y = (bbox.y0 + bbox.y1) / 2}
+	local left_center = Geom:new{ x = bbox.x0, y = (bbox.y0 + bbox.y1) / 2}
+	local anchors = {
+		upper_left, upper_center, 	upper_right,
+		left_center, 				right_center,
+		bottom_left, bottom_center, bottom_right,
+	}
+	local _, nearest = math.tmin(anchors, function(a,b)
+		return a:distance(ges.pos) > b:distance(ges.pos)
 	end)
-	if corners[1] == upper_left then
+	--DEBUG("nearest anchor", nearest)
+	if nearest == upper_left then
 		upper_left.x = ges.pos.x
 		upper_left.y = ges.pos.y
-	elseif corners[1] == bottom_right then
+	elseif nearest == bottom_right then
 		bottom_right.x = ges.pos.x
 		bottom_right.y = ges.pos.y
-	elseif corners[1] == upper_right then
+	elseif nearest == upper_right then
 		bottom_right.x = ges.pos.x
 		upper_left.y = ges.pos.y
-	elseif corners[1] == bottom_left then
+	elseif nearest == bottom_left then
 		upper_left.x = ges.pos.x
 		bottom_right.y = ges.pos.y
+	elseif nearest == upper_center then
+		upper_left.y = ges.pos.y
+	elseif nearest == right_center then
+		bottom_right.x = ges.pos.x
+	elseif nearest == bottom_center then
+		bottom_right.y = ges.pos.y
+	elseif nearest == left_center then
+		upper_left.x = ges.pos.x
 	end
 	self.screen_bbox = {
 		x0 = upper_left.x, 

--- a/frontend/ui/button.lua
+++ b/frontend/ui/button.lua
@@ -3,33 +3,55 @@ require "ui/widget"
 --[[
 a button widget
 ]]
-Button = WidgetContainer:new{
+Button = InputContainer:new{
 	text = nil, -- mandatory
-	preselect = false
+	preselect = false,
+	callback = nil,
+	margin = 0,
+	bordersize = 3,
+	background = 0,
+	radius = 15,
+	padding = 2,
+	width = nil,
+	text_font_face = "cfont",
+	text_font_size = 20,
 }
 
 function Button:init()
+	local text_widget = TextWidget:new{
+		text = self.text,
+		face = Font:getFace(self.text_font_face, self.text_font_size)
+	}
+	local text_size = text_widget:getSize()
 	-- set FrameContainer content
 	self[1] = FrameContainer:new{
-		margin = 0,
-		bordersize = 3,
-		background = 0,
-		radius = 15,
-		padding = 2,
-
+		margin = self.margin,
+		bordersize = self.bordersize,
+		background = self.background,
+		radius = self.radius,
+		padding = self.padding,
 		HorizontalGroup:new{
-			HorizontalSpan:new{ width = 8 },
-			TextWidget:new{
-				text = self.text,
-				face = Font:getFace("cfont", 20)
-			},
-			HorizontalSpan:new{ width = 8 },
+			HorizontalSpan:new{ width = (self.width - text_size.w)/2 },
+			text_widget,
+			HorizontalSpan:new{ width = (self.width - text_size.w)/2 },
 		}
 	}
 	if self.preselect then
 		self[1].color = 15
 	else
 		self[1].color = 5
+	end
+	self.dimen = self[1]:getSize()
+	if Device:isTouchDevice() then
+		self.ges_events = {
+			TapSelect = {
+				GestureRange:new{
+					ges = "tap",
+					range = self.dimen,
+				},
+				doc = "Tap Button",
+			},
+		}
 	end
 end
 
@@ -43,3 +65,7 @@ function Button:onUnfocus()
 	return true
 end
 
+function Button:onTapSelect()
+	self.callback()
+	return true
+end

--- a/frontend/ui/reader/readerkopt.lua
+++ b/frontend/ui/reader/readerkopt.lua
@@ -1,22 +1,26 @@
 
-ReaderKoptinterface = InputContainer:new{}
+ReaderKoptListener = EventListener:new{}
 
-function ReaderKoptinterface:onReadSettings(config)
-	self.normal_zoom_mode = config:readSetting("zoom_mode") or "page"
+function ReaderKoptListener:onReadSettings(config)
+	self.normal_zoom_mode = config:readSetting("normal_zoom_mode") or "page"
 	if self.document.configurable.text_wrap == 1 then
-		self.ui:handleEvent(Event:new("SetZoomMode", "page", "koptinterface"))
+		self.ui:handleEvent(Event:new("SetZoomMode", "page", "koptlistener"))
 	else
-		self.ui:handleEvent(Event:new("SetZoomMode", self.normal_zoom_mode, "koptinterface"))
+		self.ui:handleEvent(Event:new("SetZoomMode", self.normal_zoom_mode, "koptlistener"))
 	end
 end
 
-function ReaderKoptinterface:onRestoreZoomMode(zoom_mode)
-	self.ui:handleEvent(Event:new("SetZoomMode", zoom_mode or self.normal_zoom_mode, "koptinterface"))
+function ReaderKoptListener:onCloseDocument()
+	self.ui.doc_settings:saveSetting("normal_zoom_mode", self.normal_zoom_mode)
+end
+
+function ReaderKoptListener:onRestoreZoomMode(zoom_mode)
+	self.ui:handleEvent(Event:new("SetZoomMode", zoom_mode or self.normal_zoom_mode, "koptlistener"))
 	return true
 end
 
-function ReaderKoptinterface:onSetZoomMode(zoom_mode, orig)
-	if orig ~= "koptinterface" then
+function ReaderKoptListener:onSetZoomMode(zoom_mode, orig)
+	if orig ~= "koptlistener" then
 		self.normal_zoom_mode = zoom_mode
 	end
 end

--- a/frontend/ui/reader/readerkopt.lua
+++ b/frontend/ui/reader/readerkopt.lua
@@ -1,26 +1,34 @@
 
 ReaderKoptListener = EventListener:new{}
 
-function ReaderKoptListener:onReadSettings(config)
-	self.normal_zoom_mode = config:readSetting("normal_zoom_mode") or "page"
+function ReaderKoptListener:setZoomMode(zoom_mode)
 	if self.document.configurable.text_wrap == 1 then
+		-- in reflow mode only "page" zoom mode is valid so override any other zoom mode
 		self.ui:handleEvent(Event:new("SetZoomMode", "page", "koptlistener"))
 	else
-		self.ui:handleEvent(Event:new("SetZoomMode", self.normal_zoom_mode, "koptlistener"))
+		self.ui:handleEvent(Event:new("SetZoomMode", zoom_mode, "koptlistener"))
 	end
+end
+
+function ReaderKoptListener:onReadSettings(config)
+	-- normal zoom mode is zoom mode used in non-reflow mode.
+	self.normal_zoom_mode = config:readSetting("normal_zoom_mode") or "page"
+	self:setZoomMode(self.normal_zoom_mode)
 end
 
 function ReaderKoptListener:onCloseDocument()
 	self.ui.doc_settings:saveSetting("normal_zoom_mode", self.normal_zoom_mode)
 end
 
-function ReaderKoptListener:onRestoreZoomMode(zoom_mode)
-	self.ui:handleEvent(Event:new("SetZoomMode", zoom_mode or self.normal_zoom_mode, "koptlistener"))
+function ReaderKoptListener:onRestoreZoomMode()
+	-- "RestoreZoomMode" event is sent when reflow mode on/off is toggled
+	self:setZoomMode(self.normal_zoom_mode)
 	return true
 end
 
 function ReaderKoptListener:onSetZoomMode(zoom_mode, orig)
-	if orig ~= "koptlistener" then
-		self.normal_zoom_mode = zoom_mode
-	end
+	if orig == "koptlistener" then return end
+	-- capture zoom mode set outside of koptlistener which should always be normal zoom mode
+	self.normal_zoom_mode = zoom_mode
+	self:setZoomMode(self.normal_zoom_mode)
 end

--- a/frontend/ui/reader/readerview.lua
+++ b/frontend/ui/reader/readerview.lua
@@ -7,6 +7,7 @@ ReaderView = WidgetContainer:new{
 		pos = 0,
 		zoom = 1.0,
 		rotation = 0,
+		gamma = 1.0,
 		offset = {},
 		bbox = nil,
 	},
@@ -50,6 +51,7 @@ function ReaderView:paintTo(bb, x, y)
 			self.state.page,
 			self.state.zoom,
 			self.state.rotation,
+			self.state.gamma,
 			self.render_mode)
 		UIManager:scheduleIn(0, function() self.ui:handleEvent(Event:new("HintPage")) end)
 	else
@@ -160,6 +162,7 @@ function ReaderView:onReadSettings(config)
 	    table.insert(self.ui.postInitCallback, function()
 	        self:onSetScreenMode(screen_mode) end)
 	end
+	self.state.gamma = config:readSetting("gamma") or 1.0
 end
 
 function ReaderView:onPageUpdate(new_page_no)
@@ -186,12 +189,17 @@ function ReaderView:onRotationUpdate(rotation)
 	self:recalculate()
 end
 
+function ReaderView:onGammaUpdate(gamma)
+	self.state.gamma = gamma
+end
+
 function ReaderView:onHintPage()
 	if self.state.page < self.ui.document.info.number_of_pages then
 		self.ui.document:hintPage(
 			self.state.page+1, 
 			self.state.zoom, 
 			self.state.rotation, 
+			self.state.gamma, 
 			self.render_mode)
 	end
 	return true
@@ -207,4 +215,5 @@ end
 function ReaderView:onCloseDocument()
 	self.ui.doc_settings:saveSetting("render_mode", self.render_mode)
 	self.ui.doc_settings:saveSetting("screen_mode", self.screen_mode)
+	self.ui.doc_settings:saveSetting("gamma", self.state.gamma)
 end

--- a/frontend/ui/reader/readerview.lua
+++ b/frontend/ui/reader/readerview.lua
@@ -8,7 +8,7 @@ ReaderView = WidgetContainer:new{
 		zoom = 1.0,
 		rotation = 0,
 		gamma = 1.0,
-		offset = {},
+		offset = nil,
 		bbox = nil,
 	},
 	outer_page_color = 7,
@@ -40,7 +40,7 @@ function ReaderView:paintTo(bb, x, y)
 		bb:paintRect(x, y, inner_offset.x, self.ui.dimen.h, self.outer_page_color)
 		bb:paintRect(x + self.ui.dimen.w - inner_offset.x - 1, y, inner_offset.x + 1, self.ui.dimen.h, self.outer_page_color)
 	end
-	self.ui:handleEvent(Event:new("ScreenOffsetUpdate", inner_offset))
+	self.state.offset = inner_offset
 	-- draw content
 	if self.ui.document.info.has_pages then
 		self.ui.document:drawPage(

--- a/frontend/ui/reader/readerview.lua
+++ b/frontend/ui/reader/readerview.lua
@@ -138,6 +138,10 @@ function ReaderView:onSetScreenMode(new_mode)
 		Screen:setScreenMode(new_mode)
 		self.ui:handleEvent(Event:new("SetDimensions", Screen:getSize()))
 	end
+
+	if new_mode == "landscape" and self.document.info.has_pages then
+		self.ui:handleEvent(Event:new("SetZoomMode", "contentwidth"))
+	end
 	return true
 end
 

--- a/frontend/ui/reader/readerzooming.lua
+++ b/frontend/ui/reader/readerzooming.lua
@@ -95,6 +95,7 @@ function ReaderZooming:onZoom(direction)
 end
 
 function ReaderZooming:onSetZoomMode(new_mode)
+	self.view.zoom_mode = new_mode
 	if self.zoom_mode ~= new_mode then
 		DEBUG("setting zoom mode to", new_mode)
 		self.zoom_mode = new_mode

--- a/frontend/ui/readerui.lua
+++ b/frontend/ui/readerui.lua
@@ -160,13 +160,13 @@ function ReaderUI:init()
 		}
 		table.insert(self, config_dialog)
 		-- koptinterface controller
-		local koptinterface = ReaderKoptinterface:new{
+		local koptlistener = ReaderKoptListener:new{
 			dialog = self.dialog,
 			view = self[1],
 			ui = self,
 			document = self.document,
 		}
-		table.insert(self, koptinterface)
+		table.insert(self, koptlistener)
 	end
 	--DEBUG(self.doc_settings)
 	-- we only read settings after all the widgets are initialized

--- a/frontend/ui/widget.lua
+++ b/frontend/ui/widget.lua
@@ -164,6 +164,20 @@ function CenterContainer:paintTo(bb, x, y)
 end
 
 --[[
+LeftContainer aligns its content (1 widget) at the left of its own dimensions
+]]
+LeftContainer = WidgetContainer:new()
+
+function LeftContainer:paintTo(bb, x, y)
+	local contentSize = self[1]:getSize()
+	if contentSize.w > self.dimen.w or contentSize.h > self.dimen.h then
+		-- throw error? paint to scrap buffer and blit partially?
+		-- for now, we ignore this
+	end
+	self[1]:paintTo(bb, x , y + (self.dimen.h - contentSize.h)/2)
+end
+
+--[[
 RightContainer aligns its content (1 widget) at the right of its own dimensions
 ]]
 RightContainer = WidgetContainer:new()
@@ -193,7 +207,7 @@ FrameContainer = WidgetContainer:new{
 
 function FrameContainer:getSize()
 	local content_size =self[1]:getSize()
-	return {
+	return Geom:new{
 		w = content_size.w + ( self.margin + self.bordersize + self.padding ) * 2,
 		h = content_size.h + ( self.margin + self.bordersize + self.padding ) * 2
 	}

--- a/frontend/ui/widget.lua
+++ b/frontend/ui/widget.lua
@@ -8,6 +8,31 @@ require "ui/gesturedetector"
 require "ui/font"
 
 --[[
+The EventListener is an interface that handles events
+
+EventListeners have a rudimentary event handler/dispatcher that
+will call a method "onEventName" for an event with name
+"EventName"
+
+]]
+EventListener = {}
+
+function EventListener:new(o)
+	local o = o or {}
+	setmetatable(o, self)
+	self.__index = self
+	if o.init then o:init() end
+	return o
+end
+
+function EventListener:handleEvent(event)
+	if self[event.handler] then
+		return self[event.handler](self, unpack(event.args))
+	end
+end
+
+
+--[[
 This is a generic Widget interface
 
 widgets can be queried about their size and can be paint.
@@ -18,7 +43,7 @@ if the table that was given to us as parameter has an "init"
 method, it will be called. use this to set _instance_ variables
 rather than class variables.
 ]]
-Widget = {}
+Widget = EventListener:new()
 
 function Widget:new(o)
 	local o = o or {}
@@ -38,19 +63,6 @@ function Widget:getSize()
 end
 
 function Widget:paintTo(bb, x, y)
-end
-
---[[
-Widgets have a rudimentary event handler/dispatcher that
-will call a method "onEventName" for an event with name
-"EventName"
-
-These methods
-]]
-function Widget:handleEvent(event)
-	if self[event.handler] then
-		return self[event.handler](self, unpack(event.args))
-	end
 end
 
 --[[


### PR DESCRIPTION
This PR contains these patches:
1. ReaderKoptinterface is renamed to ReaderKoptListener.  Now each config entry can be converted to a configuring event with event handler defined in ReaderKoptListener.
2. Gamma correction is added for pdf/djvu reader.  Gamma value is configurable in config dialog.
3. set zoom mode to contentwidth after rotating screen to landscape
4. add bbox adjust by panning gesture
5. add confirm buttons in cropping dialog
