### PR TITLE
Adaptions for new koreader-base framework

### DIFF
--- a/reader.lua
+++ b/reader.lua
@@ -98,7 +98,9 @@ else
 end
 
 if util.isEmulated()==1 then
-	input.open("")
+	os.remove("emu_event")
+	os.execute("mkfifo emu_event")
+	input.open("emu_event")
 	-- SDL key codes
 	setEmuKeycodes()
 else

--- a/rendertext.lua
+++ b/rendertext.lua
@@ -30,7 +30,7 @@ function getGlyph(face, charcode)
 	local hash = glyphCacheHash(face.hash, charcode)
 
 	if glyphcache[hash] == nil then
-		local glyph = face.ftface:renderGlyph(charcode)
+		local glyph = face.ftface:renderGlyph(charcode, 0, 1.0)
 		local size = glyph.bb:getWidth() * glyph.bb:getHeight() / 2 + 32
 		glyphCacheClaim(size);
 		glyphcache[hash] = {


### PR DESCRIPTION
- text rendering: uses 0/1.0 for foreground/background
- emu input: uses fifo file now

This is not yet perfect, rendering text doesn't seem to "add" the values
correctly.
